### PR TITLE
Mario-bermonti/issue18

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,10 +29,12 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
+        // Added for flutter_local_notifications
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -46,6 +48,8 @@ android {
     }
 
     defaultConfig {
+        // Added for flutter_local_notifications
+        multiDexEnabled true
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.mdigit_span_tasks_ema"
         // You can update the following values to match your application needs.
@@ -70,5 +74,11 @@ flutter {
 }
 
 dependencies {
+    // Added for flutter_local_notifications
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    // Added for flutter_local_notifications
+    implementation 'androidx.window:window:1.0.0'
+    // Added for flutter_local_notifications
+    implementation 'androidx.window:window-java:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.mdigit_span_tasks_ema">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.VIBRATE" />
    <application
         android:label="mdigit_span_tasks_ema"
         android:name="${applicationName}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,9 +6,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         // START: FlutterFire Configuration
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.gms:google-services:4.3.14'
         // END: FlutterFire Configuration
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
   );
   // final Notifications notifications = Notifications();
   // await notifications.init();
-  Get.put(Notifications());
+  Get.put(LocalNotifications());
   runApp(const MyApp());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,8 +10,6 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  // final Notifications notifications = Notifications();
-  // await notifications.init();
   Get.put(LocalNotifications());
   runApp(const MyApp());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:mdigit_span_tasks_ema/src/app.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications.dart';
 import 'firebase_options.dart';
 
 Future<void> main() async {
@@ -8,5 +10,8 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  // final Notifications notifications = Notifications();
+  // await notifications.init();
+  Get.put(Notifications());
   runApp(const MyApp());
 }

--- a/lib/src/app_bar/app_bar.dart
+++ b/lib/src/app_bar/app_bar.dart
@@ -5,5 +5,5 @@ import '../notifications/notifications_button.dart';
 final AppBar appBar = AppBar(
   title: const Text('mDigitSpanTask'),
   centerTitle: true,
-  actions: const [NotificationsButton()],
+  actions: [NotificationsButton()],
 );

--- a/lib/src/app_bar/app_bar.dart
+++ b/lib/src/app_bar/app_bar.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 
+import '../notifications/notifications_button.dart';
+
 final AppBar appBar = AppBar(
   title: const Text('mDigitSpanTask'),
   centerTitle: true,
+  actions: const [NotificationsButton()],
 );

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -1,0 +1,4 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:get/get.dart';
+
+class Notifications extends GetxController {}

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -7,6 +7,19 @@ class Notifications extends GetxController {
   final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
 
+  Future<void> init() async {
+    const AndroidInitializationSettings initializationSettingsAndroid =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const DarwinInitializationSettings initializationSettingsDarwin =
+        DarwinInitializationSettings();
+    const InitializationSettings initializationSettings =
+        InitializationSettings(
+      android: initializationSettingsAndroid,
+      iOS: initializationSettingsDarwin,
+    );
+    await _notifications.initialize(initializationSettings);
+  }
+
   Future<void> showNotification({
     int id = 0,
     required String title,

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -35,9 +35,10 @@ class Notifications extends GetxController {
       throw Exception(
           'Error in setup for requesting permission to send notifications');
     }
+    bool? granted = await manager.requestNotificationsPermission();
+    if (granted == null) {
       throw Exception('Permission to send notifications not granted');
     }
-    await manager.requestNotificationsPermission();
   }
 
   Future<void> showNotification({

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -10,6 +10,7 @@ class Notifications extends GetxController {
   @override
   onInit() async {
     super.onInit();
+    await askNotificationPermission();
     await init();
   }
 

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -43,21 +43,6 @@ class Notifications extends GetxController {
     }
   }
 
-  Future<void> showNotification({
-    int id = 0,
-    required String title,
-    required String body,
-    required String payload,
-  }) async {
-    await _notifications.show(
-      id,
-      title,
-      body,
-      notificationDetails,
-      payload: payload,
-    );
-  }
-
   NotificationDetails get notificationDetails {
     const AndroidNotificationDetails androidNotificationDetails =
         AndroidNotificationDetails(
@@ -75,5 +60,20 @@ class Notifications extends GetxController {
     );
 
     return notificationDetails;
+  }
+
+  Future<void> showNotification({
+    int id = 0,
+    required String title,
+    required String body,
+    required String payload,
+  }) async {
+    await _notifications.show(
+      id,
+      title,
+      body,
+      notificationDetails,
+      payload: payload,
+    );
   }
 }

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get/get.dart';
 
-class Notifications extends GetxController {
+class LocalNotifications extends GetxController {
   final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
 

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -2,6 +2,9 @@ import 'dart:io';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get/get.dart';
 
+/// Manager for local notifications
+///
+/// It is a [GetXController] so it can be accessed from anywhere in the app.
 class LocalNotifications extends GetxController {
   final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
@@ -13,6 +16,9 @@ class LocalNotifications extends GetxController {
     await init();
   }
 
+  /// Initializes the [LocalNotifications] for android and ios.
+  ///
+  /// Must be called before using the notifications objects.
   Future<void> init() async {
     const AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('@mipmap/ic_launcher');
@@ -26,6 +32,10 @@ class LocalNotifications extends GetxController {
     await _notifications.initialize(initializationSettings);
   }
 
+  /// Asks the user during runtime for permission to send notifications.
+  ///
+  /// Only android is supported. Will cause throw an [Exception] if the
+  /// platform is not supported or the user does not grant permission.
   Future<void> askNotificationPermission() async {
     if (!Platform.isAndroid) {
       throw Exception("Notifications not implemented for this platform");
@@ -43,6 +53,7 @@ class LocalNotifications extends GetxController {
     }
   }
 
+  /// Configures the details for the supported platforms and returns them.
   NotificationDetails get notificationDetails {
     const AndroidNotificationDetails androidNotificationDetails =
         AndroidNotificationDetails(
@@ -62,6 +73,7 @@ class LocalNotifications extends GetxController {
     return notificationDetails;
   }
 
+  /// Shows a local notification to the user with the given information.
   Future<void> showNotification({
     int id = 0,
     required String title,

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -30,9 +30,27 @@ class Notifications extends GetxController {
       id,
       title,
       body,
-      getNotificationDetails(),
+      notificationDetails,
       payload: payload,
     );
   }
 
+  NotificationDetails get notificationDetails {
+    const AndroidNotificationDetails androidNotificationDetails =
+        AndroidNotificationDetails(
+      'tasks_reminders',
+      'task_reminders',
+      importance: Importance.max,
+      priority: Priority.max,
+      ticker: 'task_reminder',
+    );
+    const DarwinNotificationDetails darwinNotificationDetails =
+        DarwinNotificationDetails();
+    const NotificationDetails notificationDetails = NotificationDetails(
+      android: androidNotificationDetails,
+      iOS: darwinNotificationDetails,
+    );
+
+    return notificationDetails;
+  }
 }

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -28,6 +30,9 @@ class Notifications extends GetxController {
   }
 
   Future<void> askNotificationPermission() async {
+    if (!Platform.isAndroid) {
+      throw Exception("Notifications not implemented for this platform");
+    }
     final AndroidFlutterLocalNotificationsPlugin? manager =
         _notifications.resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>();

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -12,5 +12,14 @@ class Notifications extends GetxController {
     required String title,
     required String body,
     required String payload,
-  }) async {}
+  }) async {
+    await _notifications.show(
+      id,
+      title,
+      body,
+      getNotificationDetails(),
+      payload: payload,
+    );
+  }
+
 }

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -1,7 +1,4 @@
 import 'dart:io';
-
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get/get.dart';
 

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -7,6 +7,12 @@ class Notifications extends GetxController {
   final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
 
+  @override
+  onInit() async {
+    super.onInit();
+    await init();
+  }
+
   Future<void> init() async {
     const AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('@mipmap/ic_launcher');

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -36,7 +36,7 @@ class Notifications extends GetxController {
           'Error in setup for requesting permission to send notifications');
     }
     bool? granted = await manager.requestNotificationsPermission();
-    if (granted == null) {
+    if (granted == null || granted == false) {
       throw Exception('Permission to send notifications not granted');
     }
   }

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -6,4 +6,11 @@ import 'package:get/get.dart';
 class Notifications extends GetxController {
   final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
+
+  Future<void> showNotification({
+    int id = 0,
+    required String title,
+    required String body,
+    required String payload,
+  }) async {}
 }

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -1,4 +1,9 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get/get.dart';
 
-class Notifications extends GetxController {}
+class Notifications extends GetxController {
+  final FlutterLocalNotificationsPlugin _notifications =
+      FlutterLocalNotificationsPlugin();
+}

--- a/lib/src/notifications/notifications.dart
+++ b/lib/src/notifications/notifications.dart
@@ -26,6 +26,19 @@ class Notifications extends GetxController {
     await _notifications.initialize(initializationSettings);
   }
 
+  Future<void> askNotificationPermission() async {
+    final AndroidFlutterLocalNotificationsPlugin? manager =
+        _notifications.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    if (manager == null) {
+      throw Exception(
+          'Error in setup for requesting permission to send notifications');
+    }
+      throw Exception('Permission to send notifications not granted');
+    }
+    await manager.requestNotificationsPermission();
+  }
+
   Future<void> showNotification({
     int id = 0,
     required String title,

--- a/lib/src/notifications/notifications_button.dart
+++ b/lib/src/notifications/notifications_button.dart
@@ -4,7 +4,7 @@ import 'package:get/get.dart';
 import 'notifications.dart';
 
 class NotificationsButton extends StatelessWidget {
-  final Notifications _notifications = Get.find();
+  final LocalNotifications _notifications = Get.find();
 
   NotificationsButton({
     super.key,

--- a/lib/src/notifications/notifications_button.dart
+++ b/lib/src/notifications/notifications_button.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class NotificationsButton extends StatelessWidget {
+  const NotificationsButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () {},
+      icon: const Icon(Icons.send),
+      tooltip: 'Receive notification',
+    );
+  }
+}

--- a/lib/src/notifications/notifications_button.dart
+++ b/lib/src/notifications/notifications_button.dart
@@ -1,14 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'notifications.dart';
 
 class NotificationsButton extends StatelessWidget {
-  const NotificationsButton({
+  final Notifications _notifications = Get.find();
+
+  NotificationsButton({
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      onPressed: () {},
+      onPressed: () async {
+        await _notifications.showNotification(
+            title: 'title', body: 'body', payload: 'payload');
+      },
       icon: const Icon(Icons.send),
       tooltip: 'Receive notification',
     );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import cloud_firestore
 import firebase_auth
 import firebase_core
+import flutter_local_notifications
 import shared_preferences_foundation
 import sqlite3_flutter_libs
 
@@ -15,6 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   firebase_core: ^2.28.0
   cloud_firestore: ^4.16.0
   firebase_auth: ^4.19.0
+  flutter_local_notifications: ^17.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

The ability to send basic notifications when a button is pressed was added.

Details:
- Use the flutter_local_notifications package to send notifications
- Required configuring the android files to add/update dependencies which limit the android's api that are supported (android >= v34).

## Related Issue

Closes #18

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
