### PR TITLE
Handle taps on notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Added to send local notifications using the flutter_local_notifications package -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="ema_tasks_reminders" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-
-import 'task_list/view/task_list_page.dart';
+import 'package:mdigit_span_tasks_ema/src/routes.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -11,8 +10,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'DigitSpanTasks',
-      home: const TaskListPage(),
+      initialRoute: '/',
       theme: ThemeData(primarySwatch: Colors.grey),
+      getPages: routes,
     );
   }
 }

--- a/lib/src/ema/ema_button.dart
+++ b/lib/src/ema/ema_button.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class EMAButton extends StatelessWidget {
+  const EMAButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () {},
+      child: Text(
+        'EMA screen',
+        style: Theme.of(context).textTheme.titleLarge,
+      ),
+    );
+  }
+}

--- a/lib/src/ema/ema_screen.dart
+++ b/lib/src/ema/ema_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:mdigit_span_tasks_ema/src/app_bar/app_bar.dart';
+
+import 'ema_button.dart';
+
+class EMAScreen extends StatelessWidget {
+  const EMAScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: const Center(
+        child: EMAButton(),
+      ),
+    );
+  }
+}

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -36,6 +36,7 @@ class FirebaseNotifications extends GetxController {
   Future<void> init() async {
     await notifications.requestPermission();
     final String? token = await notifications.getToken();
+    print('token: $token');
     FirebaseMessaging.onMessage.listen(((message) async {
       await _handleForegroundMessages(message);
     }));

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -43,6 +43,9 @@ class FirebaseNotifications extends GetxController {
     await notifications
         .getInitialMessage()
         .then((message) => onNotificationTap(message));
+    FirebaseMessaging.onMessageOpenedApp.listen(onNotificationTap);
+  }
+
   void onNotificationTap(RemoteMessage? message) {
     if (message == null) return;
 

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -44,6 +44,8 @@ class FirebaseNotifications extends GetxController {
         .getInitialMessage()
         .then((message) => onNotificationTap(message));
     FirebaseMessaging.onMessageOpenedApp.listen(onNotificationTap);
+    await _localNotifications.init(
+    );
   }
 
   void onNotificationTap(RemoteMessage? message) {

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -40,5 +40,9 @@ class FirebaseNotifications extends GetxController {
     FirebaseMessaging.onMessage.listen(((message) async {
       await _handleForegroundMessages(message);
     }));
+  void onNotificationTap(RemoteMessage? message) {
+    if (message == null) return;
+
+    Get.toNamed('/emaScreen');
   }
 }

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -40,6 +40,9 @@ class FirebaseNotifications extends GetxController {
     FirebaseMessaging.onMessage.listen(((message) async {
       await _handleForegroundMessages(message);
     }));
+    await notifications
+        .getInitialMessage()
+        .then((message) => onNotificationTap(message));
   void onNotificationTap(RemoteMessage? message) {
     if (message == null) return;
 

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -53,4 +53,8 @@ class FirebaseNotifications extends GetxController {
 
     Get.toNamed('/emaScreen');
   }
+
+  void onLocalNotificationTap(NotificationResponse response) {
+    Get.toNamed('/emaScreen');
+  }
 }

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -57,6 +57,7 @@ class FirebaseNotifications extends GetxController {
     Get.toNamed('/emaScreen');
   }
 
+  /// Handles notification taps while app is in the foreground.
   void onLocalNotificationTap(NotificationResponse response) {
     Get.toNamed('/emaScreen');
   }

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -50,6 +50,7 @@ class FirebaseNotifications extends GetxController {
     );
   }
 
+  /// Handles notification taps while app is in the background or terminated.
   void onNotificationTapBG(RemoteMessage? message) {
     if (message == null) return;
 

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -43,14 +43,14 @@ class FirebaseNotifications extends GetxController {
     }));
     await notifications
         .getInitialMessage()
-        .then((message) => onNotificationTap(message));
-    FirebaseMessaging.onMessageOpenedApp.listen(onNotificationTap);
+        .then((message) => onNotificationTapBG(message));
+    FirebaseMessaging.onMessageOpenedApp.listen(onNotificationTapBG);
     await _localNotifications.init(
       onLocalNotificationTap: onLocalNotificationTap,
     );
   }
 
-  void onNotificationTap(RemoteMessage? message) {
+  void onNotificationTapBG(RemoteMessage? message) {
     if (message == null) return;
 
     Get.toNamed('/emaScreen');

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get/get.dart';
 import 'package:mdigit_span_tasks_ema/src/notifications/local_notifications.dart';
 
@@ -45,6 +46,7 @@ class FirebaseNotifications extends GetxController {
         .then((message) => onNotificationTap(message));
     FirebaseMessaging.onMessageOpenedApp.listen(onNotificationTap);
     await _localNotifications.init(
+      onLocalNotificationTap: onLocalNotificationTap,
     );
   }
 

--- a/lib/src/notifications/local_notifications.dart
+++ b/lib/src/notifications/local_notifications.dart
@@ -9,12 +9,6 @@ class LocalNotifications extends GetxController {
   final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
 
-  @override
-  onInit() async {
-    super.onInit();
-    await init();
-  }
-
   /// Initializes the [LocalNotifications] for android and ios.
   ///
   /// Must be called before using the notifications objects.

--- a/lib/src/notifications/local_notifications.dart
+++ b/lib/src/notifications/local_notifications.dart
@@ -12,7 +12,10 @@ class LocalNotifications extends GetxController {
   /// Initializes the [LocalNotifications] for android and ios.
   ///
   /// Must be called before using the notifications objects.
-  Future<void> init() async {
+  Future<void> init({
+    required void Function(NotificationResponse response)
+        onLocalNotificationTap,
+  }) async {
     const AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('@mipmap/ic_launcher');
     const DarwinInitializationSettings initializationSettingsDarwin =
@@ -22,7 +25,10 @@ class LocalNotifications extends GetxController {
       android: initializationSettingsAndroid,
       iOS: initializationSettingsDarwin,
     );
-    await _notifications.initialize(initializationSettings);
+    await _notifications.initialize(
+      initializationSettings,
+      onDidReceiveNotificationResponse: onLocalNotificationTap,
+    );
   }
 
   /// Asks the user during runtime for permission to send notifications.

--- a/lib/src/notifications/local_notifications.dart
+++ b/lib/src/notifications/local_notifications.dart
@@ -11,7 +11,9 @@ class LocalNotifications extends GetxController {
 
   /// Initializes the [LocalNotifications] for android and ios.
   ///
-  /// Must be called before using the notifications objects.
+  /// It requires [onLocalNotificationTap] that specifies how to handle taps on
+  /// notifications. This method must be called before using the notifications
+  /// object.
   Future<void> init({
     required void Function(NotificationResponse response)
         onLocalNotificationTap,

--- a/lib/src/notifications/local_notifications.dart
+++ b/lib/src/notifications/local_notifications.dart
@@ -56,8 +56,8 @@ class LocalNotifications extends GetxController {
   NotificationDetails get notificationDetails {
     const AndroidNotificationDetails androidNotificationDetails =
         AndroidNotificationDetails(
-      'tasks_reminders',
-      'task_reminders',
+      'ema_tasks_reminders',
+      'ema_tasks_reminders',
       importance: Importance.max,
       priority: Priority.max,
       ticker: 'task_reminder',

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -1,0 +1,8 @@
+import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/ema/ema_screen.dart';
+import 'package:mdigit_span_tasks_ema/src/task_list/view/task_list_page.dart';
+
+final List<GetPage> routes = <GetPage>[
+  GetPage(name: '/', page: () => const TaskListPage()),
+  GetPage(name: '/emaScreen', page: () => const EMAScreen()),
+];


### PR DESCRIPTION
## Description

When users tap on a notification is they are directed to a screen to complete the EMA tasks.

These changes include:
- using named routes for navigation
- handling taps on firebase and local notifications separately
- init LocalNotifications manually and passing it a notification handler
- updating docstrings

## Related Issue

Closes issue #24

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
