### PR TITLE
Run EMA tasks in EMA screen

### DIFF
--- a/lib/src/ema/ema_button.dart
+++ b/lib/src/ema/ema_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mdigit_span_tasks_ema/src/ema/run_ema_tasks.dart';
 
 class EMAButton extends StatelessWidget {
   const EMAButton({
@@ -8,7 +9,9 @@ class EMAButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ElevatedButton(
-      onPressed: () {},
+      onPressed: () {
+        runEMATasks();
+      },
       child: Text(
         'EMA screen',
         style: Theme.of(context).textTheme.titleLarge,

--- a/lib/src/ema/run_ema_tasks.dart
+++ b/lib/src/ema/run_ema_tasks.dart
@@ -4,8 +4,20 @@ import 'package:mdigit_span_tasks_ema/src/digit_span_tasks/task_runners/run_dsb.
 import '../digit_span_tasks/task_runners/run_dsf.dart';
 import '../services/run_session.dart';
 
-Future<void> runEMATasks() async {
+void runEMAdsf() async {
   await runSession(taskRunner: runDigitSpanForward, taskName: 'ds_forward');
+}
+
+void runEMAdsb() async {
   await runSession(taskRunner: runDigitSpanBackwards, taskName: 'ds_backwards');
+}
+
+final List<Function> emaTasks = <Function>[runEMAdsf, runEMAdsb];
+
+Future<void> runEMATasks() async {
+  emaTasks.shuffle();
+  for (Function emaTask in emaTasks) {
+    await emaTask();
+  }
   Get.back();
 }

--- a/lib/src/ema/run_ema_tasks.dart
+++ b/lib/src/ema/run_ema_tasks.dart
@@ -1,0 +1,11 @@
+import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/digit_span_tasks/task_runners/run_dsb.dart';
+
+import '../digit_span_tasks/task_runners/run_dsf.dart';
+import '../services/run_session.dart';
+
+Future<void> runEMATasks() async {
+  await runSession(taskRunner: runDigitSpanForward, taskName: 'ds_forward');
+  await runSession(taskRunner: runDigitSpanBackwards, taskName: 'ds_backwards');
+  Get.back();
+}

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -8,7 +8,7 @@ import 'package:mdigit_span_tasks_ema/src/services/data_processor.dart';
 /// Run a data collection session
 /// Running a session includes configuring everything needed and running a
 /// cognitive task specified with [taskRunner].
-void runSession(
+Future<void> runSession(
     {required Function({
       required String participantID,
       required String sessionID,

--- a/lib/src/task_list/view/task_buttons.dart
+++ b/lib/src/task_list/view/task_buttons.dart
@@ -11,8 +11,10 @@ class DSBButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ElevatedButton(
-      onPressed: () => runSession(
-          taskRunner: runDigitSpanBackwards, taskName: 'ds_backwards'),
+      onPressed: () async {
+        await runSession(
+            taskRunner: runDigitSpanBackwards, taskName: 'ds_backwards');
+      },
       child: Text(
         'Digit Span Backwards',
         style: Theme.of(context).textTheme.titleLarge,
@@ -29,8 +31,10 @@ class DSFButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ElevatedButton(
-      onPressed: () =>
-          runSession(taskRunner: runDigitSpanForward, taskName: 'ds_forward'),
+      onPressed: () async {
+        await runSession(
+            taskRunner: runDigitSpanForward, taskName: 'ds_forward');
+      },
       child: Text(
         'Digit Span Forward',
         style: Theme.of(context).textTheme.titleLarge,


### PR DESCRIPTION
## Description

All EMA as run in random order when the begin button in the EMA screen is pressed.

It required making the runSession service async so we can await it. 

These changes introduce 3 challenges that must be addressed in the future:
1. Errors occur if the EMA task sequence is started by pressing on a notification while already running a manual task.
2. The EMA screen appears briefly between EMA tasks
3. The EMA screen appears briefly before moving to the home screen after completing all EMA tasks

## Related Issue

Close #26

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
