### PR TITLE
Subscribe to EMA tasks reminders

### DIFF
--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -48,6 +48,7 @@ class FirebaseNotifications extends GetxController {
     await _localNotifications.init(
       onLocalNotificationTap: onLocalNotificationTap,
     );
+    await subscribeToEMAReminders();
   }
 
   /// Handles notification taps while app is in the background or terminated.
@@ -66,4 +67,7 @@ class FirebaseNotifications extends GetxController {
     await notifications.subscribeToTopic(topic);
   }
 
+  Future<void> subscribeToEMAReminders() async {
+    await subscribeToTopic(topic: 'ema_tasks_reminders');
+  }
 }

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -61,4 +61,9 @@ class FirebaseNotifications extends GetxController {
   void onLocalNotificationTap(NotificationResponse response) {
     Get.toNamed('/emaScreen');
   }
+
+  Future<void> subscribeToTopic({required String topic}) async {
+    await notifications.subscribeToTopic(topic);
+  }
+
 }

--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -63,10 +63,12 @@ class FirebaseNotifications extends GetxController {
     Get.toNamed('/emaScreen');
   }
 
+  /// Subscribes the current device to the FCM topic specified by [topic].
   Future<void> subscribeToTopic({required String topic}) async {
     await notifications.subscribeToTopic(topic);
   }
 
+  /// Subscribes the current device to the FCM topic on ema_tasks_reminders.
   Future<void> subscribeToEMAReminders() async {
     await subscribeToTopic(topic: 'ema_tasks_reminders');
   }


### PR DESCRIPTION
## Description

These changes include a general method to subscribe to FCM topics and a specific one that uses the general method to subscribe to the EMA tasks reminders

## Related Issue

Close #28

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
