### PR TITLE
feat: Subscribe to daily EMA reminders

### DIFF
--- a/lib/src/notifications/firebase_notifications.dart
+++ b/lib/src/notifications/firebase_notifications.dart
@@ -70,6 +70,8 @@ class FirebaseNotifications extends GetxController {
 
   /// Subscribes the current device to the FCM topic on ema_tasks_reminders.
   Future<void> subscribeToEMAReminders() async {
-    await subscribeToTopic(topic: 'ema_tasks_reminders');
+    await subscribeToTopic(topic: 'ema_tasks_reminders_am');
+    await subscribeToTopic(topic: 'ema_tasks_reminders_afternoon');
+    await subscribeToTopic(topic: 'ema_tasks_reminders_night');
   }
 }


### PR DESCRIPTION
## Description

Subscribes to EMA reminders in the morning, afternoon and night.

## Related Issue

Closes #30

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
