### PR TITLE
Don't allow participants to "go back" from EMA screen

### DIFF
--- a/lib/src/app_bar/app_bar.dart
+++ b/lib/src/app_bar/app_bar.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../notifications/notifications_button.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  /// Whether a button to allow the user to go back to the previous screen
+  /// will be presented.
   final bool allowBack;
 
   const CustomAppBar({super.key, this.allowBack = false});

--- a/lib/src/app_bar/app_bar.dart
+++ b/lib/src/app_bar/app_bar.dart
@@ -7,3 +7,22 @@ final AppBar appBar = AppBar(
   centerTitle: true,
   actions: [NotificationsButton()],
 );
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final bool allowBack;
+
+  const CustomAppBar({super.key, this.allowBack = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: const Text('mDigitSpanTask'),
+      centerTitle: true,
+      automaticallyImplyLeading: allowBack,
+      actions: [NotificationsButton()],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/src/app_bar/app_bar.dart
+++ b/lib/src/app_bar/app_bar.dart
@@ -2,12 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../notifications/notifications_button.dart';
 
-final AppBar appBar = AppBar(
-  title: const Text('mDigitSpanTask'),
-  centerTitle: true,
-  actions: [NotificationsButton()],
-);
-
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final bool allowBack;
 

--- a/lib/src/ema/ema_screen.dart
+++ b/lib/src/ema/ema_screen.dart
@@ -8,9 +8,9 @@ class EMAScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: appBar,
-      body: const Center(
+    return const Scaffold(
+      appBar: CustomAppBar(),
+      body: Center(
         child: EMAButton(),
       ),
     );

--- a/lib/src/task_list/view/task_list_page.dart
+++ b/lib/src/task_list/view/task_list_page.dart
@@ -8,7 +8,7 @@ class TaskListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: appBar,
+      appBar: const CustomAppBar(),
       body: const Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## Description

We defined a custom app bar object and we removed the "back button" from the app bar in the EMA screen.

## Related Issue

Closes #32

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
