### PR TITLE
Upgrade the digit_span_tasks package

### DIFF
--- a/lib/src/app_bar/app_bar.dart
+++ b/lib/src/app_bar/app_bar.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../notifications/notifications_button.dart';
-
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// Whether a button to allow the user to go back to the previous screen
   /// will be presented.
@@ -15,7 +13,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       title: const Text('mDigits'),
       centerTitle: true,
       automaticallyImplyLeading: allowBack,
-      actions: [NotificationsButton()],
+      // actions: [NotificationsButton()],
     );
   }
 

--- a/lib/src/digit_span_tasks/prep_data.dart
+++ b/lib/src/digit_span_tasks/prep_data.dart
@@ -1,0 +1,25 @@
+import 'package:cognitive_data/cognitive_data.dart';
+import 'package:digit_span_tasks/digit_span_tasks.dart';
+
+DigitSpanTaskData prepData({
+  required DigitSpanTaskData practiceData,
+  required DigitSpanTaskData experimentalData,
+}) {
+  final Session session = Session(
+      participantID: practiceData.session.participantID,
+      sessionID: practiceData.session.sessionID,
+      startTime: practiceData.session.startTime,
+      endTime: experimentalData.session.endTime);
+
+  final Device device = Device(
+    participantID: practiceData.session.participantID,
+    sessionID: practiceData.session.sessionID,
+  );
+
+  final List<Trial> trials = practiceData.trials + experimentalData.trials;
+
+  final DigitSpanTaskData data =
+      DigitSpanTaskData(trials: trials, session: session, device: device);
+
+  return data;
+}

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -1,23 +1,43 @@
 import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsb.dart';
+import '../prep_data.dart';
 
 /// Configure and start the DSB
 Future<DigitSpanTaskData> runDigitSpanBackwards({
   required String participantID,
   required String sessionID,
 }) async {
+  DigitSpanTask task;
   final DSBConfig dsbConfig = DSBConfig();
-  final UserConfig userConfig = UserConfig(
-    stimListPractice: dsbConfig.practiceStim,
-    stimListExperimental: dsbConfig.experimentalStim,
+  final UserConfig userConfigPractice = UserConfig(
+    stimList: dsbConfig.practiceStim,
     participantID: participantID,
     sessionID: sessionID,
+    sessionType: SessionType.practice,
   );
 
-  DigitSpanTaskData data = await Get.to(() => DigitSpanBackwards(
-        config: userConfig,
-      ));
+  task = DigitSpanTask(
+    config: userConfigPractice,
+  );
+  DigitSpanTaskData practiceData = await task.run();
+
+  final UserConfig userConfigExperimental = UserConfig(
+    stimList: dsbConfig.experimentalStim,
+    participantID: participantID,
+    sessionID: sessionID,
+    sessionType: SessionType.experimental,
+  );
+
+  task = DigitSpanTask(
+    config: userConfigExperimental,
+  );
+  DigitSpanTaskData experimentalData = await task.run();
+
+  final DigitSpanTaskData data = prepData(
+    practiceData: practiceData,
+    experimentalData: experimentalData,
+  );
 
   return data;
 }

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -1,5 +1,8 @@
 import 'package:digit_span_tasks/digit_span_tasks.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/ui_components/loading_screen.dart';
+import '../../ui_components/instructions.dart';
 import '../config/config_dsb.dart';
 import '../prep_data.dart';
 
@@ -8,6 +11,36 @@ Future<DigitSpanTaskData> runDigitSpanBackwards({
   required String participantID,
   required String sessionID,
 }) async {
+  Get.to(() => const LoadingScreen());
+  await Get.to(
+    () => Instructions(
+        instructions: InstructionsText(
+            'Recuerda los números al revés al orden en que los veas')),
+  );
+  await Get.to(
+    () => Instructions(
+        instructions: Column(
+      children: [
+        InstructionsText('Ejemplo:'),
+        InstructionsText('Si ves 49'),
+        InstructionsText('Escribe 94'),
+      ],
+    )),
+  );
+  await Get.to(
+    () => Instructions(
+        instructions: Column(
+      children: [
+        InstructionsText('Ejemplo:'),
+        InstructionsText('Si ves 491'),
+        InstructionsText('Escribe 194'),
+      ],
+    )),
+  );
+  await Get.to(
+    () =>
+        Instructions(instructions: InstructionsText('Comencemos practicando')),
+  );
   DigitSpanTask task;
   final DSBConfig dsbConfig = DSBConfig();
   final UserConfig userConfigPractice = UserConfig(
@@ -21,6 +54,17 @@ Future<DigitSpanTaskData> runDigitSpanBackwards({
     config: userConfigPractice,
   );
   DigitSpanTaskData practiceData = await task.run();
+
+  await Get.to(
+    () => Instructions(
+        instructions: InstructionsText(
+            'Ahora trabajaremos con los ejercicios principales')),
+  );
+  await Get.to(
+    () => Instructions(
+        instructions: InstructionsText(
+            'Recuerda escribir los números al revés al orden en que los veas')),
+  );
 
   final UserConfig userConfigExperimental = UserConfig(
     stimList: dsbConfig.experimentalStim,
@@ -39,5 +83,9 @@ Future<DigitSpanTaskData> runDigitSpanBackwards({
     experimentalData: experimentalData,
   );
 
+  await Get.to(() => Instructions(
+      instructions: InstructionsText('¡Terminamos esta actividad!')));
+
+  Get.toNamed('/');
   return data;
 }

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -1,22 +1,43 @@
 import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsf.dart';
+import '../prep_data.dart';
 
 /// Configure and start the DSF
 Future<DigitSpanTaskData> runDigitSpanForward({
   required String participantID,
   required String sessionID,
 }) async {
+  DigitSpanTask task;
   final DSFConfig dsfConfig = DSFConfig();
-  final UserConfig userConfig = UserConfig(
-      stimListPractice: dsfConfig.practiceStim,
-      stimListExperimental: dsfConfig.experimentalStim,
-      participantID: participantID,
-      sessionID: sessionID);
+  final UserConfig userConfigPractice = UserConfig(
+    stimList: dsfConfig.practiceStim,
+    participantID: participantID,
+    sessionID: sessionID,
+    sessionType: SessionType.practice,
+  );
 
-  DigitSpanTaskData data = await Get.to(() => DigitSpanForward(
-        config: userConfig,
-      ));
+  task = DigitSpanTask(
+    config: userConfigPractice,
+  );
+  DigitSpanTaskData practiceData = await task.run();
+
+  final UserConfig userConfigExperimental = UserConfig(
+    stimList: dsfConfig.experimentalStim,
+    participantID: participantID,
+    sessionID: sessionID,
+    sessionType: SessionType.experimental,
+  );
+
+  task = DigitSpanTask(
+    config: userConfigExperimental,
+  );
+  DigitSpanTaskData experimentalData = await task.run();
+
+  final DigitSpanTaskData data = prepData(
+    practiceData: practiceData,
+    experimentalData: experimentalData,
+  );
 
   return data;
 }

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -1,5 +1,8 @@
 import 'package:digit_span_tasks/digit_span_tasks.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/ui_components/instructions.dart';
+import '../../ui_components/loading_screen.dart';
 import '../config/config_dsf.dart';
 import '../prep_data.dart';
 
@@ -8,6 +11,17 @@ Future<DigitSpanTaskData> runDigitSpanForward({
   required String participantID,
   required String sessionID,
 }) async {
+  Get.to(() => const LoadingScreen());
+  await Get.to(
+    () => Instructions(
+      instructions:
+          InstructionsText('Recuerda los números en el orden en que los veas'),
+    ),
+  );
+  await Get.to(
+    () =>
+        Instructions(instructions: InstructionsText('Comencemos practicando')),
+  );
   DigitSpanTask task;
   final DSFConfig dsfConfig = DSFConfig();
   final UserConfig userConfigPractice = UserConfig(
@@ -21,6 +35,17 @@ Future<DigitSpanTaskData> runDigitSpanForward({
     config: userConfigPractice,
   );
   DigitSpanTaskData practiceData = await task.run();
+
+  await Get.to(
+    () => Instructions(
+        instructions: InstructionsText(
+            'Ahora trabajaremos con los ejercicios principales')),
+  );
+  await Get.to(
+    () => Instructions(
+        instructions: InstructionsText(
+            'Recuerda escribir los números en el orden en que los veas')),
+  );
 
   final UserConfig userConfigExperimental = UserConfig(
     stimList: dsfConfig.experimentalStim,
@@ -39,5 +64,9 @@ Future<DigitSpanTaskData> runDigitSpanForward({
     experimentalData: experimentalData,
   );
 
+  await Get.to(() => Instructions(
+      instructions: InstructionsText('¡Terminamos esta actividad!')));
+
+  Get.toNamed('/');
   return data;
 }

--- a/lib/src/services/show_screen_duration.dart
+++ b/lib/src/services/show_screen_duration.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Present a [screen] [Widget] for [duration].
+Future<void> showScreenForDuration({
+  required Widget Function() screen,
+  required Duration duration,
+}) async {
+  Get.to(screen());
+  await Future.delayed(
+    duration,
+  );
+}

--- a/lib/src/ui_components/instructions.dart
+++ b/lib/src/ui_components/instructions.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/ui_components/screen.dart';
+
+class Instructions extends StatelessWidget {
+  final Widget instructions;
+
+  const Instructions({super.key, required this.instructions});
+
+  @override
+  Widget build(BuildContext context) {
+    return Screen(
+      children: Column(
+        children: <Widget>[
+          instructions,
+          const SizedBox(height: 30),
+          ElevatedButton(
+            onPressed: () => Get.back(),
+            child: Text(
+              'Continuar',
+              style: Theme.of(context).textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class InstructionsText extends StatelessWidget {
+  final String text;
+  InstructionsText(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.titleLarge,
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/lib/src/ui_components/loading_screen.dart
+++ b/lib/src/ui_components/loading_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class LoadingScreen extends StatelessWidget {
+  const LoadingScreen({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/src/ui_components/screen.dart
+++ b/lib/src/ui_components/screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class Screen extends StatelessWidget {
+  final Widget children;
+
+  final AppBar? appBar;
+
+  const Screen({super.key, required this.children, this.appBar});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 50),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              children,
+            ],
+          ),
+        ),
+      ),
+      backgroundColor: Colors.grey[300],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   digit_span_tasks:
     git:
       url: https://github.com/mario-bermonti/digit_span_tasks.git
-      ref: mario-bermonti/issue123
+      ref: 13fa6f29b7e58b36499e9947f58b46bbb88ad4d6
   cognitive_data:
     git:
       url: https://github.com/mario-bermonti/cognitive_data.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   digit_span_tasks:
     git:
       url: https://github.com/mario-bermonti/digit_span_tasks.git
-      ref: 3c1f56f12c1dea5ead718c9f981de2aee2b17162
+      ref: mario-bermonti/issue123
   cognitive_data:
     git:
       url: https://github.com/mario-bermonti/cognitive_data.git


### PR DESCRIPTION
## Description

The latest version of the `digit_span_tasks` removed instructions and the distiction between DSF/DSB. Upgrading it required mdigit_span_tasks to present instructions and adapt tasks to distinguish between DSF/DSB (instructions and stimuli).

## Related Issue

Closes #42

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
