### PR TITLE
Fix: Redirect to appropriate screen after cognitive task

### DIFF
--- a/lib/src/digit_span_tasks/config/config.dart
+++ b/lib/src/digit_span_tasks/config/config.dart
@@ -6,4 +6,5 @@ class DigitSpanTaskConfig extends GetxController {
   late String sessionID;
   late String taskName;
   late DSStim stim;
+  late String nextScreen;
 }

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -89,6 +89,6 @@ Future<DigitSpanTaskData> runDigitSpanBackwards() async {
   await Get.to(() => Instructions(
       instructions: InstructionsText('¡Terminamos esta actividad!')));
 
-  Get.toNamed('/');
+  Get.toNamed(config.nextScreen);
   return data;
 }

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -66,6 +66,6 @@ Future<DigitSpanTaskData> runDigitSpanForward() async {
   await Get.to(() => Instructions(
       instructions: InstructionsText('¡Terminamos esta actividad!')));
 
-  Get.toNamed('/');
+  Get.toNamed(config.nextScreen);
   return data;
 }

--- a/lib/src/ema/run_ema_tasks.dart
+++ b/lib/src/ema/run_ema_tasks.dart
@@ -25,8 +25,11 @@ void runEMAdsb() async {
 final List<Function> emaTasks = <Function>[runEMAdsf, runEMAdsb];
 
 Future<void> runEMATasks() async {
+  final DigitSpanTaskConfig config = Get.find();
+  config.nextScreen = '/loading';
   emaTasks.shuffle();
   for (Function emaTask in emaTasks) {
     await emaTask();
   }
+  Get.toNamed('/');
 }

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -1,8 +1,10 @@
 import 'package:get/get.dart';
 import 'package:mdigit_span_tasks_ema/src/ema/ema_screen.dart';
 import 'package:mdigit_span_tasks_ema/src/task_list/view/task_list_page.dart';
+import 'package:mdigit_span_tasks_ema/src/ui_components/loading_screen.dart';
 
 final List<GetPage> routes = <GetPage>[
   GetPage(name: '/', page: () => const TaskListPage()),
   GetPage(name: '/emaScreen', page: () => const EMAScreen()),
+  GetPage(name: '/loading', page: () => const LoadingScreen()),
 ];

--- a/lib/src/task_list/view/task_buttons.dart
+++ b/lib/src/task_list/view/task_buttons.dart
@@ -20,6 +20,7 @@ class DSBButton extends StatelessWidget {
         final DigitSpanTaskConfig config = Get.find();
         config.taskName = 'dsb';
         config.stim = dsbStim;
+        config.nextScreen = '/';
         await runSession(taskRunner: runDigitSpanBackwards);
       },
       child: Text(
@@ -42,6 +43,7 @@ class DSFButton extends StatelessWidget {
         final DigitSpanTaskConfig config = Get.find();
         config.taskName = 'dsf';
         config.stim = dsfStim;
+        config.nextScreen = '/';
         await runSession(taskRunner: runDigitSpanForward);
       },
       child: Text(


### PR DESCRIPTION
## Description

The screen to navigate to after the cognitive task is now specified in the config and used by session runners.

## Related Issue

Closes #48

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
