### PR TITLE
Handle baseline survey data

### DIFF
--- a/docs/design/survey_data.md
+++ b/docs/design/survey_data.md
@@ -1,0 +1,19 @@
+# Design of survey data
+
+## Requirements
+
+- Create a data object with the minimum reasonable data that survey data should have in a research study
+- Return data to caller 
+- Objects must be serializable
+
+## Structure
+
+### Custom objects
+
+- Survey data object
+  - Survey level info
+  - List of survey items
+  
+- Item data object
+  - metadata about item
+  - response

--- a/lib/src/baseline/data/survey_data.dart
+++ b/lib/src/baseline/data/survey_data.dart
@@ -5,6 +5,7 @@ import 'package:research_package/model.dart';
 import 'survey_item_data.dart';
 
 part 'survey_data.freezed.dart';
+part 'survey_data.g.dart';
 
 /// Model that represents the data for a single survey item.
 @freezed
@@ -46,4 +47,7 @@ class SurveyData with _$SurveyData {
 
     return surveyData;
   }
+
+  factory SurveyData.fromJson(Map<String, dynamic> json) =>
+      _$SurveyDataFromJson(json);
 }

--- a/lib/src/baseline/data/survey_data.dart
+++ b/lib/src/baseline/data/survey_data.dart
@@ -1,3 +1,5 @@
+import 'package:research_package/model.dart';
+
 import 'survey_item_data.dart';
 
 class SurveyData {
@@ -22,4 +24,11 @@ class SurveyData {
     required this.endTime,
     required this.items,
   });
+
+  /// named constructor
+  SurveyData.fromRPTaskResult(RPTaskResult rpSurveyData) {
+    /// build survey metadata
+    /// iterate over items and build them using the named constructor in
+    /// the item's object.
+  }
 }

--- a/lib/src/baseline/data/survey_data.dart
+++ b/lib/src/baseline/data/survey_data.dart
@@ -1,34 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
 import 'package:research_package/model.dart';
 
 import 'survey_item_data.dart';
 
-class SurveyData {
-  /// Short description of the item
-  final String identifier;
+part 'survey_data.freezed.dart';
 
-  /// Longer description than the [identifier].
-  /// It's usually the text presented to the participant or
-  /// a long description.
-  final String description;
-  final String startTime;
-  final String endTime;
+/// Model that represents the data for a single survey item.
+@freezed
+class SurveyData with _$SurveyData {
+  const factory SurveyData({
+    required DateTime? startTime,
+    required DateTime? endTime,
 
-  /// List of survey items that include the data about the item and
-  /// the participant's responses.
-  final List<SurveyItemData> items;
+    /// Short description of the item
+    required String identifier,
 
-  SurveyData({
-    required this.identifier,
-    required this.description,
-    required this.startTime,
-    required this.endTime,
-    required this.items,
-  });
+    /// Longer description than the [identifier].
+    /// It's usually the text presented to the participant or
+    /// a long description.
+    required String description,
 
-  /// named constructor
-  SurveyData.fromRPTaskResult(RPTaskResult rpSurveyData) {
-    /// build survey metadata
-    /// iterate over items and build them using the named constructor in
-    /// the item's object.
-  }
+    /// List of survey items that include metadata about the item and
+    /// the participant's response.
+    required List<SurveyItemData> items,
+  }) = _SurveyData;
 }

--- a/lib/src/baseline/data/survey_data.dart
+++ b/lib/src/baseline/data/survey_data.dart
@@ -25,4 +25,25 @@ class SurveyData with _$SurveyData {
     /// the participant's response.
     required List<SurveyItemData> items,
   }) = _SurveyData;
+
+  factory SurveyData.fromRPTaskResult({
+    required RPTaskResult rpSurveyData,
+    required String description,
+  }) {
+    final Iterable<RPResult> rawItems = rpSurveyData.results.values;
+    final List<SurveyItemData> surveyItems = rawItems
+        .map((RPResult rawItem) =>
+            SurveyItemData.fromRPStepResult(rawItem as RPStepResult))
+        .toList();
+
+    final SurveyData surveyData = SurveyData(
+      startTime: rpSurveyData.startDate,
+      endTime: rpSurveyData.endDate,
+      identifier: rpSurveyData.identifier,
+      description: description,
+      items: surveyItems,
+    );
+
+    return surveyData;
+  }
 }

--- a/lib/src/baseline/data/survey_data.dart
+++ b/lib/src/baseline/data/survey_data.dart
@@ -1,0 +1,25 @@
+import 'survey_item_data.dart';
+
+class SurveyData {
+  /// Short description of the item
+  final String identifier;
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  final String description;
+  final String startTime;
+  final String endTime;
+
+  /// List of survey items that include the data about the item and
+  /// the participant's responses.
+  final List<SurveyItemData> items;
+
+  SurveyData({
+    required this.identifier,
+    required this.description,
+    required this.startTime,
+    required this.endTime,
+    required this.items,
+  });
+}

--- a/lib/src/baseline/data/survey_data.freezed.dart
+++ b/lib/src/baseline/data/survey_data.freezed.dart
@@ -1,0 +1,268 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'survey_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$SurveyData {
+  DateTime? get startTime => throw _privateConstructorUsedError;
+  DateTime? get endTime => throw _privateConstructorUsedError;
+
+  /// Short description of the item
+  String get identifier => throw _privateConstructorUsedError;
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  String get description => throw _privateConstructorUsedError;
+
+  /// List of survey items that include metadata about the item and
+  /// the participant's response.
+  List<SurveyItemData> get items => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SurveyDataCopyWith<SurveyData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SurveyDataCopyWith<$Res> {
+  factory $SurveyDataCopyWith(
+          SurveyData value, $Res Function(SurveyData) then) =
+      _$SurveyDataCopyWithImpl<$Res, SurveyData>;
+  @useResult
+  $Res call(
+      {DateTime? startTime,
+      DateTime? endTime,
+      String identifier,
+      String description,
+      List<SurveyItemData> items});
+}
+
+/// @nodoc
+class _$SurveyDataCopyWithImpl<$Res, $Val extends SurveyData>
+    implements $SurveyDataCopyWith<$Res> {
+  _$SurveyDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? startTime = freezed,
+    Object? endTime = freezed,
+    Object? identifier = null,
+    Object? description = null,
+    Object? items = null,
+  }) {
+    return _then(_value.copyWith(
+      startTime: freezed == startTime
+          ? _value.startTime
+          : startTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endTime: freezed == endTime
+          ? _value.endTime
+          : endTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      identifier: null == identifier
+          ? _value.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      items: null == items
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<SurveyItemData>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SurveyDataImplCopyWith<$Res>
+    implements $SurveyDataCopyWith<$Res> {
+  factory _$$SurveyDataImplCopyWith(
+          _$SurveyDataImpl value, $Res Function(_$SurveyDataImpl) then) =
+      __$$SurveyDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {DateTime? startTime,
+      DateTime? endTime,
+      String identifier,
+      String description,
+      List<SurveyItemData> items});
+}
+
+/// @nodoc
+class __$$SurveyDataImplCopyWithImpl<$Res>
+    extends _$SurveyDataCopyWithImpl<$Res, _$SurveyDataImpl>
+    implements _$$SurveyDataImplCopyWith<$Res> {
+  __$$SurveyDataImplCopyWithImpl(
+      _$SurveyDataImpl _value, $Res Function(_$SurveyDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? startTime = freezed,
+    Object? endTime = freezed,
+    Object? identifier = null,
+    Object? description = null,
+    Object? items = null,
+  }) {
+    return _then(_$SurveyDataImpl(
+      startTime: freezed == startTime
+          ? _value.startTime
+          : startTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endTime: freezed == endTime
+          ? _value.endTime
+          : endTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      identifier: null == identifier
+          ? _value.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      items: null == items
+          ? _value._items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<SurveyItemData>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SurveyDataImpl with DiagnosticableTreeMixin implements _SurveyData {
+  const _$SurveyDataImpl(
+      {required this.startTime,
+      required this.endTime,
+      required this.identifier,
+      required this.description,
+      required final List<SurveyItemData> items})
+      : _items = items;
+
+  @override
+  final DateTime? startTime;
+  @override
+  final DateTime? endTime;
+
+  /// Short description of the item
+  @override
+  final String identifier;
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  @override
+  final String description;
+
+  /// List of survey items that include metadata about the item and
+  /// the participant's response.
+  final List<SurveyItemData> _items;
+
+  /// List of survey items that include metadata about the item and
+  /// the participant's response.
+  @override
+  List<SurveyItemData> get items {
+    if (_items is EqualUnmodifiableListView) return _items;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_items);
+  }
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'SurveyData(startTime: $startTime, endTime: $endTime, identifier: $identifier, description: $description, items: $items)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'SurveyData'))
+      ..add(DiagnosticsProperty('startTime', startTime))
+      ..add(DiagnosticsProperty('endTime', endTime))
+      ..add(DiagnosticsProperty('identifier', identifier))
+      ..add(DiagnosticsProperty('description', description))
+      ..add(DiagnosticsProperty('items', items));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SurveyDataImpl &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
+            (identical(other.endTime, endTime) || other.endTime == endTime) &&
+            (identical(other.identifier, identifier) ||
+                other.identifier == identifier) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            const DeepCollectionEquality().equals(other._items, _items));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, startTime, endTime, identifier,
+      description, const DeepCollectionEquality().hash(_items));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SurveyDataImplCopyWith<_$SurveyDataImpl> get copyWith =>
+      __$$SurveyDataImplCopyWithImpl<_$SurveyDataImpl>(this, _$identity);
+}
+
+abstract class _SurveyData implements SurveyData {
+  const factory _SurveyData(
+      {required final DateTime? startTime,
+      required final DateTime? endTime,
+      required final String identifier,
+      required final String description,
+      required final List<SurveyItemData> items}) = _$SurveyDataImpl;
+
+  @override
+  DateTime? get startTime;
+  @override
+  DateTime? get endTime;
+  @override
+
+  /// Short description of the item
+  String get identifier;
+  @override
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  String get description;
+  @override
+
+  /// List of survey items that include metadata about the item and
+  /// the participant's response.
+  List<SurveyItemData> get items;
+  @override
+  @JsonKey(ignore: true)
+  _$$SurveyDataImplCopyWith<_$SurveyDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/baseline/data/survey_data.freezed.dart
+++ b/lib/src/baseline/data/survey_data.freezed.dart
@@ -14,6 +14,10 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
+SurveyData _$SurveyDataFromJson(Map<String, dynamic> json) {
+  return _SurveyData.fromJson(json);
+}
+
 /// @nodoc
 mixin _$SurveyData {
   DateTime? get startTime => throw _privateConstructorUsedError;
@@ -31,6 +35,7 @@ mixin _$SurveyData {
   /// the participant's response.
   List<SurveyItemData> get items => throw _privateConstructorUsedError;
 
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $SurveyDataCopyWith<SurveyData> get copyWith =>
       throw _privateConstructorUsedError;
@@ -153,7 +158,7 @@ class __$$SurveyDataImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
+@JsonSerializable()
 class _$SurveyDataImpl with DiagnosticableTreeMixin implements _SurveyData {
   const _$SurveyDataImpl(
       {required this.startTime,
@@ -162,6 +167,9 @@ class _$SurveyDataImpl with DiagnosticableTreeMixin implements _SurveyData {
       required this.description,
       required final List<SurveyItemData> items})
       : _items = items;
+
+  factory _$SurveyDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SurveyDataImplFromJson(json);
 
   @override
   final DateTime? startTime;
@@ -223,6 +231,7 @@ class _$SurveyDataImpl with DiagnosticableTreeMixin implements _SurveyData {
             const DeepCollectionEquality().equals(other._items, _items));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, startTime, endTime, identifier,
       description, const DeepCollectionEquality().hash(_items));
@@ -232,6 +241,13 @@ class _$SurveyDataImpl with DiagnosticableTreeMixin implements _SurveyData {
   @pragma('vm:prefer-inline')
   _$$SurveyDataImplCopyWith<_$SurveyDataImpl> get copyWith =>
       __$$SurveyDataImplCopyWithImpl<_$SurveyDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SurveyDataImplToJson(
+      this,
+    );
+  }
 }
 
 abstract class _SurveyData implements SurveyData {
@@ -241,6 +257,9 @@ abstract class _SurveyData implements SurveyData {
       required final String identifier,
       required final String description,
       required final List<SurveyItemData> items}) = _$SurveyDataImpl;
+
+  factory _SurveyData.fromJson(Map<String, dynamic> json) =
+      _$SurveyDataImpl.fromJson;
 
   @override
   DateTime? get startTime;

--- a/lib/src/baseline/data/survey_data.g.dart
+++ b/lib/src/baseline/data/survey_data.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'survey_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SurveyDataImpl _$$SurveyDataImplFromJson(Map<String, dynamic> json) =>
+    _$SurveyDataImpl(
+      startTime: json['startTime'] == null
+          ? null
+          : DateTime.parse(json['startTime'] as String),
+      endTime: json['endTime'] == null
+          ? null
+          : DateTime.parse(json['endTime'] as String),
+      identifier: json['identifier'] as String,
+      description: json['description'] as String,
+      items: (json['items'] as List<dynamic>)
+          .map((e) => SurveyItemData.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$SurveyDataImplToJson(_$SurveyDataImpl instance) =>
+    <String, dynamic>{
+      'startTime': instance.startTime?.toIso8601String(),
+      'endTime': instance.endTime?.toIso8601String(),
+      'identifier': instance.identifier,
+      'description': instance.description,
+      'items': instance.items,
+    };

--- a/lib/src/baseline/data/survey_item_data.dart
+++ b/lib/src/baseline/data/survey_item_data.dart
@@ -4,6 +4,7 @@ import 'package:mdigit_span_tasks_ema/src/baseline/services/rp_converters.dart';
 import 'package:research_package/research_package.dart';
 
 part 'survey_item_data.freezed.dart';
+part 'survey_item_data.g.dart';
 
 /// Model that represents the data for a single survey item.
 @freezed
@@ -48,4 +49,7 @@ class SurveyItemData with _$SurveyItemData {
     );
     return item;
   }
+
+  factory SurveyItemData.fromJson(Map<String, dynamic> json) =>
+      _$SurveyItemDataFromJson(json);
 }

--- a/lib/src/baseline/data/survey_item_data.dart
+++ b/lib/src/baseline/data/survey_item_data.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter/foundation.dart';
+import 'package:research_package/research_package.dart';
 
 part 'survey_item_data.freezed.dart';
 
@@ -26,4 +27,10 @@ class SurveyItemData with _$SurveyItemData {
     /// Possible choices the participant select from.
     List<String>? choices,
   }) = _SurveyItemData;
+
+  SurveyItemData.fromRPTaskResult(RPTaskResult rpItemData) {
+    /// extract metadata
+    /// extract choices, if applicable - service
+    /// extract response - service
+  }
 }

--- a/lib/src/baseline/data/survey_item_data.dart
+++ b/lib/src/baseline/data/survey_item_data.dart
@@ -1,0 +1,29 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part 'survey_item_data.freezed.dart';
+
+/// Model that represents the data for a single survey item.
+@freezed
+class SurveyItemData with _$SurveyItemData {
+  const factory SurveyItemData({
+    required DateTime? startTime,
+    required DateTime? endTime,
+
+    /// Short description of the item
+    required String identifier,
+
+    /// Longer description than the [identifier].
+    /// It's usually the text presented to the participant or
+    /// a long description.
+    required String description,
+
+    /// Type of survey item present to understand the response scale.
+    /// Common options are single choice, multiple choice, free text.
+    required String type,
+    required String response,
+
+    /// Possible choices the participant select from.
+    List<String>? choices,
+  }) = _SurveyItemData;
+}

--- a/lib/src/baseline/data/survey_item_data.dart
+++ b/lib/src/baseline/data/survey_item_data.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter/foundation.dart';
+import 'package:mdigit_span_tasks_ema/src/baseline/services/rp_converters.dart';
 import 'package:research_package/research_package.dart';
 
 part 'survey_item_data.freezed.dart';
@@ -28,9 +29,23 @@ class SurveyItemData with _$SurveyItemData {
     List<String>? choices,
   }) = _SurveyItemData;
 
-  SurveyItemData.fromRPTaskResult(RPTaskResult rpItemData) {
-    /// extract metadata
-    /// extract choices, if applicable - service
-    /// extract response - service
+  factory SurveyItemData.fromRPStepResult(RPStepResult rpItem) {
+    final String itemType = rpItem.answerFormat.questionType.name;
+    final String response = getAnswer(
+      rpAnswer: rpItem.results.values,
+      itemType: itemType,
+    );
+    final List<String>? choices = getChoices(rpItem.answerFormat);
+
+    final SurveyItemData item = SurveyItemData(
+      startTime: rpItem.startDate,
+      endTime: rpItem.endDate,
+      identifier: rpItem.identifier,
+      description: rpItem.questionTitle,
+      type: itemType,
+      response: response,
+      choices: choices,
+    );
+    return item;
   }
 }

--- a/lib/src/baseline/data/survey_item_data.freezed.dart
+++ b/lib/src/baseline/data/survey_item_data.freezed.dart
@@ -14,6 +14,10 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
+SurveyItemData _$SurveyItemDataFromJson(Map<String, dynamic> json) {
+  return _SurveyItemData.fromJson(json);
+}
+
 /// @nodoc
 mixin _$SurveyItemData {
   DateTime? get startTime => throw _privateConstructorUsedError;
@@ -35,6 +39,7 @@ mixin _$SurveyItemData {
   /// Possible choices the participant select from.
   List<String>? get choices => throw _privateConstructorUsedError;
 
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $SurveyItemDataCopyWith<SurveyItemData> get copyWith =>
       throw _privateConstructorUsedError;
@@ -181,7 +186,7 @@ class __$$SurveyItemDataImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
+@JsonSerializable()
 class _$SurveyItemDataImpl
     with DiagnosticableTreeMixin
     implements _SurveyItemData {
@@ -194,6 +199,9 @@ class _$SurveyItemDataImpl
       required this.response,
       final List<String>? choices})
       : _choices = choices;
+
+  factory _$SurveyItemDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SurveyItemDataImplFromJson(json);
 
   @override
   final DateTime? startTime;
@@ -267,6 +275,7 @@ class _$SurveyItemDataImpl
             const DeepCollectionEquality().equals(other._choices, _choices));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -284,6 +293,13 @@ class _$SurveyItemDataImpl
   _$$SurveyItemDataImplCopyWith<_$SurveyItemDataImpl> get copyWith =>
       __$$SurveyItemDataImplCopyWithImpl<_$SurveyItemDataImpl>(
           this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SurveyItemDataImplToJson(
+      this,
+    );
+  }
 }
 
 abstract class _SurveyItemData implements SurveyItemData {
@@ -295,6 +311,9 @@ abstract class _SurveyItemData implements SurveyItemData {
       required final String type,
       required final String response,
       final List<String>? choices}) = _$SurveyItemDataImpl;
+
+  factory _SurveyItemData.fromJson(Map<String, dynamic> json) =
+      _$SurveyItemDataImpl.fromJson;
 
   @override
   DateTime? get startTime;

--- a/lib/src/baseline/data/survey_item_data.freezed.dart
+++ b/lib/src/baseline/data/survey_item_data.freezed.dart
@@ -1,0 +1,328 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'survey_item_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$SurveyItemData {
+  DateTime? get startTime => throw _privateConstructorUsedError;
+  DateTime? get endTime => throw _privateConstructorUsedError;
+
+  /// Short description of the item
+  String get identifier => throw _privateConstructorUsedError;
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  String get description => throw _privateConstructorUsedError;
+
+  /// Type of survey item present to understand the response scale.
+  /// Common options are single choice, multiple choice, free text.
+  String get type => throw _privateConstructorUsedError;
+  String get response => throw _privateConstructorUsedError;
+
+  /// Possible choices the participant select from.
+  List<String>? get choices => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SurveyItemDataCopyWith<SurveyItemData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SurveyItemDataCopyWith<$Res> {
+  factory $SurveyItemDataCopyWith(
+          SurveyItemData value, $Res Function(SurveyItemData) then) =
+      _$SurveyItemDataCopyWithImpl<$Res, SurveyItemData>;
+  @useResult
+  $Res call(
+      {DateTime? startTime,
+      DateTime? endTime,
+      String identifier,
+      String description,
+      String type,
+      String response,
+      List<String>? choices});
+}
+
+/// @nodoc
+class _$SurveyItemDataCopyWithImpl<$Res, $Val extends SurveyItemData>
+    implements $SurveyItemDataCopyWith<$Res> {
+  _$SurveyItemDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? startTime = freezed,
+    Object? endTime = freezed,
+    Object? identifier = null,
+    Object? description = null,
+    Object? type = null,
+    Object? response = null,
+    Object? choices = freezed,
+  }) {
+    return _then(_value.copyWith(
+      startTime: freezed == startTime
+          ? _value.startTime
+          : startTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endTime: freezed == endTime
+          ? _value.endTime
+          : endTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      identifier: null == identifier
+          ? _value.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+      response: null == response
+          ? _value.response
+          : response // ignore: cast_nullable_to_non_nullable
+              as String,
+      choices: freezed == choices
+          ? _value.choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SurveyItemDataImplCopyWith<$Res>
+    implements $SurveyItemDataCopyWith<$Res> {
+  factory _$$SurveyItemDataImplCopyWith(_$SurveyItemDataImpl value,
+          $Res Function(_$SurveyItemDataImpl) then) =
+      __$$SurveyItemDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {DateTime? startTime,
+      DateTime? endTime,
+      String identifier,
+      String description,
+      String type,
+      String response,
+      List<String>? choices});
+}
+
+/// @nodoc
+class __$$SurveyItemDataImplCopyWithImpl<$Res>
+    extends _$SurveyItemDataCopyWithImpl<$Res, _$SurveyItemDataImpl>
+    implements _$$SurveyItemDataImplCopyWith<$Res> {
+  __$$SurveyItemDataImplCopyWithImpl(
+      _$SurveyItemDataImpl _value, $Res Function(_$SurveyItemDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? startTime = freezed,
+    Object? endTime = freezed,
+    Object? identifier = null,
+    Object? description = null,
+    Object? type = null,
+    Object? response = null,
+    Object? choices = freezed,
+  }) {
+    return _then(_$SurveyItemDataImpl(
+      startTime: freezed == startTime
+          ? _value.startTime
+          : startTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endTime: freezed == endTime
+          ? _value.endTime
+          : endTime // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      identifier: null == identifier
+          ? _value.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+      response: null == response
+          ? _value.response
+          : response // ignore: cast_nullable_to_non_nullable
+              as String,
+      choices: freezed == choices
+          ? _value._choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SurveyItemDataImpl
+    with DiagnosticableTreeMixin
+    implements _SurveyItemData {
+  const _$SurveyItemDataImpl(
+      {required this.startTime,
+      required this.endTime,
+      required this.identifier,
+      required this.description,
+      required this.type,
+      required this.response,
+      final List<String>? choices})
+      : _choices = choices;
+
+  @override
+  final DateTime? startTime;
+  @override
+  final DateTime? endTime;
+
+  /// Short description of the item
+  @override
+  final String identifier;
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  @override
+  final String description;
+
+  /// Type of survey item present to understand the response scale.
+  /// Common options are single choice, multiple choice, free text.
+  @override
+  final String type;
+  @override
+  final String response;
+
+  /// Possible choices the participant select from.
+  final List<String>? _choices;
+
+  /// Possible choices the participant select from.
+  @override
+  List<String>? get choices {
+    final value = _choices;
+    if (value == null) return null;
+    if (_choices is EqualUnmodifiableListView) return _choices;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'SurveyItemData(startTime: $startTime, endTime: $endTime, identifier: $identifier, description: $description, type: $type, response: $response, choices: $choices)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'SurveyItemData'))
+      ..add(DiagnosticsProperty('startTime', startTime))
+      ..add(DiagnosticsProperty('endTime', endTime))
+      ..add(DiagnosticsProperty('identifier', identifier))
+      ..add(DiagnosticsProperty('description', description))
+      ..add(DiagnosticsProperty('type', type))
+      ..add(DiagnosticsProperty('response', response))
+      ..add(DiagnosticsProperty('choices', choices));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SurveyItemDataImpl &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
+            (identical(other.endTime, endTime) || other.endTime == endTime) &&
+            (identical(other.identifier, identifier) ||
+                other.identifier == identifier) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.response, response) ||
+                other.response == response) &&
+            const DeepCollectionEquality().equals(other._choices, _choices));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      startTime,
+      endTime,
+      identifier,
+      description,
+      type,
+      response,
+      const DeepCollectionEquality().hash(_choices));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SurveyItemDataImplCopyWith<_$SurveyItemDataImpl> get copyWith =>
+      __$$SurveyItemDataImplCopyWithImpl<_$SurveyItemDataImpl>(
+          this, _$identity);
+}
+
+abstract class _SurveyItemData implements SurveyItemData {
+  const factory _SurveyItemData(
+      {required final DateTime? startTime,
+      required final DateTime? endTime,
+      required final String identifier,
+      required final String description,
+      required final String type,
+      required final String response,
+      final List<String>? choices}) = _$SurveyItemDataImpl;
+
+  @override
+  DateTime? get startTime;
+  @override
+  DateTime? get endTime;
+  @override
+
+  /// Short description of the item
+  String get identifier;
+  @override
+
+  /// Longer description than the [identifier].
+  /// It's usually the text presented to the participant or
+  /// a long description.
+  String get description;
+  @override
+
+  /// Type of survey item present to understand the response scale.
+  /// Common options are single choice, multiple choice, free text.
+  String get type;
+  @override
+  String get response;
+  @override
+
+  /// Possible choices the participant select from.
+  List<String>? get choices;
+  @override
+  @JsonKey(ignore: true)
+  _$$SurveyItemDataImplCopyWith<_$SurveyItemDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/baseline/data/survey_item_data.g.dart
+++ b/lib/src/baseline/data/survey_item_data.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'survey_item_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SurveyItemDataImpl _$$SurveyItemDataImplFromJson(Map<String, dynamic> json) =>
+    _$SurveyItemDataImpl(
+      startTime: json['startTime'] == null
+          ? null
+          : DateTime.parse(json['startTime'] as String),
+      endTime: json['endTime'] == null
+          ? null
+          : DateTime.parse(json['endTime'] as String),
+      identifier: json['identifier'] as String,
+      description: json['description'] as String,
+      type: json['type'] as String,
+      response: json['response'] as String,
+      choices:
+          (json['choices'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$$SurveyItemDataImplToJson(
+        _$SurveyItemDataImpl instance) =>
+    <String, dynamic>{
+      'startTime': instance.startTime?.toIso8601String(),
+      'endTime': instance.endTime?.toIso8601String(),
+      'identifier': instance.identifier,
+      'description': instance.description,
+      'type': instance.type,
+      'response': instance.response,
+      'choices': instance.choices,
+    };

--- a/lib/src/baseline/services/rp_converters.dart
+++ b/lib/src/baseline/services/rp_converters.dart
@@ -1,3 +1,5 @@
+import 'package:research_package/model.dart';
+
 /// Format the answer to an [RPQuestion].
 /// Currently supports Date and SingleChoice questions.
 String getAnswer({
@@ -10,5 +12,21 @@ String getAnswer({
     return rpAnswer.first.text as String;
   } else {
     throw UnimplementedError('Support for $itemType has not been implemented');
+  }
+}
+
+/// Extracts the labels of choices from the survey items, if applicable.
+/// The item's [RPAnswerFormat] is used to determine if this is applicable for
+/// the survey item type.
+List<String>? getChoices(RPAnswerFormat answerFormat) {
+  final String questionType = answerFormat.questionType.name;
+  if (questionType == 'Date') {
+    return null;
+  } else {
+    final RPChoiceAnswerFormat choiceAnswerFormat =
+        answerFormat as RPChoiceAnswerFormat;
+    final List<String> choicesLabels =
+        extractLabelFromChoices(choiceAnswerFormat.choices);
+    return choicesLabels;
   }
 }

--- a/lib/src/baseline/services/rp_converters.dart
+++ b/lib/src/baseline/services/rp_converters.dart
@@ -1,0 +1,14 @@
+/// Format the answer to an [RPQuestion].
+/// Currently supports Date and SingleChoice questions.
+String getAnswer({
+  required Iterable<dynamic> rpAnswer,
+  required String itemType,
+}) {
+  if (itemType == 'Date') {
+    return rpAnswer.first;
+  } else if (itemType == 'SingleChoice') {
+    return rpAnswer.first.text as String;
+  } else {
+    throw UnimplementedError('Support for $itemType has not been implemented');
+  }
+}

--- a/lib/src/baseline/services/rp_converters.dart
+++ b/lib/src/baseline/services/rp_converters.dart
@@ -26,7 +26,14 @@ List<String>? getChoices(RPAnswerFormat answerFormat) {
     final RPChoiceAnswerFormat choiceAnswerFormat =
         answerFormat as RPChoiceAnswerFormat;
     final List<String> choicesLabels =
-        extractLabelFromChoices(choiceAnswerFormat.choices);
+        getLabelFromChoices(choiceAnswerFormat.choices);
     return choicesLabels;
   }
+}
+
+/// Extracts the label (i.e., text field) from each [RPChoice] in [choices].
+List<String> getLabelFromChoices(List<RPChoice> choices) {
+  final List<String> labels =
+      choices.map((RPChoice choice) => choice.text).toList();
+  return labels;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   firebase_messaging: ^14.8.1
   research_package: ^1.5.0
   get_storage: ^2.1.1
-  freezed: ^2.5.2
   freezed_annotation: ^2.4.2
   json_annotation: ^4.9.0
 
@@ -42,6 +41,7 @@ dev_dependencies:
   flutter_launcher_icons: ^0.13.1
   rename: ^3.0.2
   build_runner: ^2.4.9
+  freezed: ^2.5.2
   json_serializable: ^6.8.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   firebase_messaging: ^14.8.1
   research_package: ^1.5.0
   get_storage: ^2.1.1
+  freezed: ^2.5.2
+  freezed_annotation: ^2.4.2
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   flutter_test:
@@ -38,6 +41,8 @@ dev_dependencies:
   firebase_auth_mocks: ^0.13.0
   flutter_launcher_icons: ^0.13.1
   rename: ^3.0.2
+  build_runner: ^2.4.9
+  json_serializable: ^6.8.0
 
 flutter:
   uses-material-design: true

--- a/test/src/baseline/data/survey_data_test.dart
+++ b/test/src/baseline/data/survey_data_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mdigit_span_tasks_ema/src/baseline/data/survey_data.dart';
+import 'package:mdigit_span_tasks_ema/src/baseline/data/survey_item_data.dart';
+import 'package:research_package/research_package.dart';
+
+void main() {
+  test(
+    """Given a valid [RPTaskResult] and a description, 
+    SurveyData.fromRPTaskResult returns a valid [SurveyData]""",
+    () {
+      /// survey items
+      final RPStepResult rawDateItem = RPStepResult(
+        identifier: "today",
+        questionTitle: "What date is it?",
+        answerFormat: RPDateTimeAnswerFormat(
+          dateTimeAnswerStyle: RPDateTimeAnswerStyle.Date,
+        ),
+      );
+      rawDateItem.setResult("2024-04-07 00:00:00.000");
+      final SurveyItemData formattedDateItem = SurveyItemData(
+        startTime: rawDateItem.startDate,
+        endTime: rawDateItem.endDate,
+        identifier: "today",
+        description: "What date is it?",
+        type: "Date",
+        response: "2024-04-07 00:00:00.000",
+      );
+
+      final RPStepResult rawColorItem = RPStepResult(
+        identifier: 'color',
+        questionTitle: 'What color do you prefer?',
+        answerFormat: RPChoiceAnswerFormat(
+          choices: [
+            RPChoice(
+              text: 'Black',
+              value: 0,
+              isFreeText: false,
+            ),
+            RPChoice(
+              text: 'White',
+              value: 1,
+              isFreeText: false,
+            ),
+          ],
+          answerStyle: RPChoiceAnswerStyle.SingleChoice,
+        ),
+      );
+      rawColorItem.setResult(RPChoice(
+        text: 'Black',
+        value: 0,
+        isFreeText: false,
+      ));
+      final SurveyItemData formattedColorItem = SurveyItemData(
+        startTime: rawColorItem.startDate,
+        endTime: rawColorItem.endDate,
+        identifier: "color",
+        description: "What color do you prefer?",
+        type: "SingleChoice",
+        response: "Black",
+        choices: ["Black", "White"],
+      );
+
+      /// Survey data
+      final RPTaskResult rawSurveyData = RPTaskResult(
+        identifier: 'test_survey',
+      );
+      rawSurveyData.setStepResultForIdentifier('today', rawDateItem);
+      rawSurveyData.setStepResultForIdentifier('color', rawColorItem);
+      const String description = "Test survey for unittesting";
+
+      final SurveyData expectedSurveyData = SurveyData(
+        startTime: rawSurveyData.startDate,
+        endTime: rawSurveyData.endDate,
+        identifier: rawSurveyData.identifier,
+        description: description,
+        items: [formattedDateItem, formattedColorItem],
+      );
+
+      final SurveyData actualSurveyData = SurveyData.fromRPTaskResult(
+        rpSurveyData: rawSurveyData,
+        description: description,
+      );
+
+      expect(actualSurveyData, expectedSurveyData);
+    },
+  );
+}

--- a/test/src/baseline/data/survey_item_data_test.dart
+++ b/test/src/baseline/data/survey_item_data_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mdigit_span_tasks_ema/src/baseline/data/survey_item_data.dart';
+import 'package:research_package/research_package.dart';
+
+void main() {
+  group("SurveyItemData.fromRPStepResult", () {
+    test(
+      """Given a valid [RPStepResult] for a Date survey item,
+      returns a valid SurveyItemData.""",
+      () {
+        final RPStepResult rawItem = RPStepResult(
+          identifier: "today",
+          questionTitle: "What date is it?",
+          answerFormat: RPDateTimeAnswerFormat(
+            dateTimeAnswerStyle: RPDateTimeAnswerStyle.Date,
+          ),
+        );
+        rawItem.setResult("2024-04-07 00:00:00.000");
+
+        final SurveyItemData expectedItem = SurveyItemData(
+          startTime: rawItem.startDate!,
+          endTime: rawItem.endDate!,
+          identifier: "today",
+          description: "What date is it?",
+          type: "Date",
+          response: "2024-04-07 00:00:00.000",
+        );
+
+        final SurveyItemData actualItem =
+            SurveyItemData.fromRPStepResult(rawItem);
+
+        expect(actualItem, expectedItem);
+      },
+    );
+  });
+}

--- a/test/src/baseline/data/survey_item_data_test.dart
+++ b/test/src/baseline/data/survey_item_data_test.dart
@@ -32,5 +32,50 @@ void main() {
         expect(actualItem, expectedItem);
       },
     );
+    test(
+      """Given a valid [RPStepResult] for a SingleChoice survey item,
+      returns a valid SurveyItemData.""",
+      () {
+        final RPStepResult rawItem = RPStepResult(
+          identifier: 'color',
+          questionTitle: 'What color do you prefer?',
+          answerFormat: RPChoiceAnswerFormat(
+            choices: [
+              RPChoice(
+                text: 'Black',
+                value: 0,
+                isFreeText: false,
+              ),
+              RPChoice(
+                text: 'White',
+                value: 1,
+                isFreeText: false,
+              ),
+            ],
+            answerStyle: RPChoiceAnswerStyle.SingleChoice,
+          ),
+        );
+        rawItem.setResult(RPChoice(
+          text: 'Black',
+          value: 0,
+          isFreeText: false,
+        ));
+
+        final SurveyItemData expectedItem = SurveyItemData(
+          startTime: rawItem.startDate!,
+          endTime: rawItem.endDate!,
+          identifier: "color",
+          description: "What color do you prefer?",
+          type: "SingleChoice",
+          response: "Black",
+          choices: ["Black", "White"],
+        );
+
+        final SurveyItemData actualItem =
+            SurveyItemData.fromRPStepResult(rawItem);
+
+        expect(actualItem, expectedItem);
+      },
+    );
   });
 }

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -166,4 +166,30 @@ void main() {
       },
     );
   });
+  group("getLabelFromChoices", () {
+    test(
+      """Given a List<RPChoice>, returns a List<String> with each choice's
+       label (i.e., text).""",
+      () {
+        final List<RPChoice> rawChoices = [
+          RPChoice(
+            text: 'Black',
+            value: 0,
+            isFreeText: false,
+          ),
+          RPChoice(
+            text: 'White',
+            value: 1,
+            isFreeText: false,
+          ),
+        ];
+
+        final List<String> expectedChoices = ['Black', 'White'];
+
+        final List<String> actualChoices = getLabelFromChoices(rawChoices);
+
+        expect(actualChoices, expectedChoices);
+      },
+    );
+  });
 }

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mdigit_span_tasks_ema/src/baseline/services/rp_converters.dart';
+import 'package:research_package/research_package.dart';
 
 void main() {
   group(

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -111,4 +111,22 @@ void main() {
       );
     },
   );
+  group("getChoices", () {
+    test(
+      "Given an [RPAnswerFormat] for a Date survey item, returns null",
+      () {
+        final RPStepResult dateStep = RPStepResult(
+          identifier: "today",
+          questionTitle: "What date is it?",
+          answerFormat: RPDateTimeAnswerFormat(
+              dateTimeAnswerStyle: RPDateTimeAnswerStyle.Date),
+        );
+        dateStep.setResult("2024-04-07 00:00:00.000");
+
+        final List<String>? actualChoices = getChoices(dateStep.answerFormat);
+
+        expect(actualChoices, null);
+      },
+    );
+  });
 }

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -29,6 +29,46 @@ void main() {
           expect(actualAnswer, expectedAnswer);
         },
       );
+      test(
+        """Given a SingleChoice itemType and the values inside a results object 
+        of a [RPStepResult] that contains 'Black' in the text field of the 
+        [RPChoice] that contains its answer, returns 'Black'""",
+        () {
+          final RPStepResult colorStep = RPStepResult(
+            identifier: 'color',
+            questionTitle: 'What color do you prefer?',
+            answerFormat: RPChoiceAnswerFormat(
+              choices: [
+                RPChoice(
+                  text: 'Black',
+                  value: 0,
+                  isFreeText: false,
+                ),
+                RPChoice(
+                  text: 'White',
+                  value: 1,
+                  isFreeText: false,
+                ),
+              ],
+              answerStyle: RPChoiceAnswerStyle.SingleChoice,
+            ),
+          );
+          colorStep.setResult(RPChoice(
+            text: 'Black',
+            value: 0,
+            isFreeText: false,
+          ));
+          const String itemType = "SingleChoice";
+          const String expectedAnswer = "Black";
+
+          final String actualAnswer = getAnswer(
+            rpAnswer: colorStep.results.values,
+            itemType: itemType,
+          );
+
+          expect(actualAnswer, expectedAnswer);
+        },
+      );
     },
   );
 }

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -69,6 +69,46 @@ void main() {
           expect(actualAnswer, expectedAnswer);
         },
       );
+      test(
+        """Given a MultipleChoice itemType and the values inside a results object 
+        of a [RPStepResult] that contains 'Black' in the text field of the 
+        [RPChoice] that contains its answer, throws an UnimplementedError.'""",
+        () {
+          final RPStepResult colorStep = RPStepResult(
+            identifier: 'color',
+            questionTitle: 'What color do you prefer?',
+            answerFormat: RPChoiceAnswerFormat(
+              choices: [
+                RPChoice(
+                  text: 'Black',
+                  value: 0,
+                  isFreeText: false,
+                ),
+                RPChoice(
+                  text: 'White',
+                  value: 1,
+                  isFreeText: false,
+                ),
+              ],
+              answerStyle: RPChoiceAnswerStyle.SingleChoice,
+            ),
+          );
+          colorStep.setResult(RPChoice(
+            text: 'Black',
+            value: 0,
+            isFreeText: false,
+          ));
+          const String itemType = "MultipleChoice";
+
+          expect(
+            () => getAnswer(
+              rpAnswer: colorStep.results.values,
+              itemType: itemType,
+            ),
+            throwsUnimplementedError,
+          );
+        },
+      );
     },
   );
 }

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -128,5 +128,41 @@ void main() {
         expect(actualChoices, null);
       },
     );
+    test(
+      """Given an [RPAnswerFormat] for a SingleChoice survey item, returns 
+      a List of Strings with the text (i.e., label) of each choice.""",
+      () {
+        final RPStepResult colorStep = RPStepResult(
+          identifier: 'color',
+          questionTitle: 'What color do you prefer?',
+          answerFormat: RPChoiceAnswerFormat(
+            choices: [
+              RPChoice(
+                text: 'Black',
+                value: 0,
+                isFreeText: false,
+              ),
+              RPChoice(
+                text: 'White',
+                value: 1,
+                isFreeText: false,
+              ),
+            ],
+            answerStyle: RPChoiceAnswerStyle.SingleChoice,
+          ),
+        );
+        colorStep.setResult(RPChoice(
+          text: 'Black',
+          value: 0,
+          isFreeText: false,
+        ));
+
+        final List<String> expectedChoices = ['Black', 'White'];
+
+        final List<String>? actualChoices = getChoices(colorStep.answerFormat);
+
+        expect(actualChoices, expectedChoices);
+      },
+    );
   });
 }

--- a/test/src/baseline/services/rp_converters_test.dart
+++ b/test/src/baseline/services/rp_converters_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mdigit_span_tasks_ema/src/baseline/services/rp_converters.dart';
+
+void main() {
+  group(
+    "getAnswer",
+    () {
+      test(
+        """Given a Date itemType and the values inside a results object of a
+        [RPStepResult] with the answer '2024-04-07 00:00:00.000' 
+      returns '2024-04-07 00:00:00.000'""",
+        () {
+          final RPStepResult dateStep = RPStepResult(
+            identifier: "today",
+            questionTitle: "What date is it?",
+            answerFormat: RPDateTimeAnswerFormat(
+                dateTimeAnswerStyle: RPDateTimeAnswerStyle.Date),
+          );
+          dateStep.setResult("2024-04-07 00:00:00.000");
+
+          const String itemType = "Date";
+          const String expectedAnswer = "2024-04-07 00:00:00.000";
+
+          final String actualAnswer = getAnswer(
+            rpAnswer: dateStep.results.values,
+            itemType: itemType,
+          );
+
+          expect(actualAnswer, expectedAnswer);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Description

These changes convert the results of an [research_package](https://github.com/cph-cachet/research.package) to an internal representation that contains a subset of the data.

The result is an object that contains all the data for the survey and its items. The items themselves are internal objects that are easy to work with.

All these objects are serializable and comparable thanks to [`json_serializable`](https://pub.dev/packages/json_serializable) and [`freezed`](https://pub.dev/packages/freezed).

## Related Issue

Fixes #63

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
