### PR TITLE
Use participant controller during cognitive sessions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ Future<void> main() async {
   Get.put(FirebaseNotifications());
   final Participant participant =
       await Auth(auth: FirebaseAuth.instance).signIn();
-  Get.put(participant);
+  Get.put(participant, permanent: true);
   Get.put(DigitSpanTaskConfig(), permanent: true);
   runApp(const MyApp());
 }

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -1,9 +1,7 @@
 import 'package:digit_span_tasks/digit_span_tasks.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get/get.dart';
 import 'package:mdigit_span_tasks_ema/src/auth/participant.dart';
 import 'package:mdigit_span_tasks_ema/src/data_manager/session_id_creator.dart';
-import 'package:mdigit_span_tasks_ema/src/auth/auth.dart';
 import 'package:mdigit_span_tasks_ema/src/digit_span_tasks/config/config.dart';
 import 'package:mdigit_span_tasks_ema/src/services/data_processor.dart';
 
@@ -14,8 +12,7 @@ Future<void> runSession({
   required Function taskRunner,
 }) async {
   final DigitSpanTaskConfig config = Get.find();
-  final Participant participant =
-      await Auth(auth: FirebaseAuth.instance).signIn();
+  final Participant participant = Get.find();
   config.participantID = participant.id;
 
   /// We use the startTime for the practice session to create a single


### PR DESCRIPTION
## Description

Use the participant controller when running cognitive sessions. It required inserting the participant controller permanently.

## Related Issue

Closes #73

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
