### PR TITLE
Improve how demo survey responses are handled

### DIFF
--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1,2 +1,3 @@
 {
+  "Skip this question": "Salta esta pregunta"
 }

--- a/lib/src/dob_question.dart
+++ b/lib/src/dob_question.dart
@@ -5,4 +5,5 @@ RPQuestionStep dobQuestion = RPQuestionStep(
   title: '¿Cuál es tu fecha de nacimiento?',
   answerFormat:
       RPDateTimeAnswerFormat(dateTimeAnswerStyle: RPDateTimeAnswerStyle.Date),
+  optional: true,
 );

--- a/lib/src/surveys/data/survey_item_data.dart
+++ b/lib/src/surveys/data/survey_item_data.dart
@@ -24,7 +24,7 @@ class SurveyItemData with _$SurveyItemData {
     /// Type of survey item present to understand the response scale.
     /// Common options are single choice, multiple choice, free text.
     required String type,
-    required String response,
+    required String? response,
 
     /// Possible choices the participant select from.
     List<String>? choices,
@@ -32,7 +32,7 @@ class SurveyItemData with _$SurveyItemData {
 
   factory SurveyItemData.fromRPStepResult(RPStepResult rpItem) {
     final String itemType = rpItem.answerFormat.questionType.name;
-    final String response = getAnswer(
+    final String? response = getAnswer(
       rpAnswer: rpItem.results.values,
       itemType: itemType,
     );

--- a/lib/src/surveys/data/survey_item_data.freezed.dart
+++ b/lib/src/surveys/data/survey_item_data.freezed.dart
@@ -34,7 +34,7 @@ mixin _$SurveyItemData {
   /// Type of survey item present to understand the response scale.
   /// Common options are single choice, multiple choice, free text.
   String get type => throw _privateConstructorUsedError;
-  String get response => throw _privateConstructorUsedError;
+  String? get response => throw _privateConstructorUsedError;
 
   /// Possible choices the participant select from.
   List<String>? get choices => throw _privateConstructorUsedError;
@@ -57,7 +57,7 @@ abstract class $SurveyItemDataCopyWith<$Res> {
       String identifier,
       String description,
       String type,
-      String response,
+      String? response,
       List<String>? choices});
 }
 
@@ -79,7 +79,7 @@ class _$SurveyItemDataCopyWithImpl<$Res, $Val extends SurveyItemData>
     Object? identifier = null,
     Object? description = null,
     Object? type = null,
-    Object? response = null,
+    Object? response = freezed,
     Object? choices = freezed,
   }) {
     return _then(_value.copyWith(
@@ -103,10 +103,10 @@ class _$SurveyItemDataCopyWithImpl<$Res, $Val extends SurveyItemData>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as String,
-      response: null == response
+      response: freezed == response
           ? _value.response
           : response // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       choices: freezed == choices
           ? _value.choices
           : choices // ignore: cast_nullable_to_non_nullable
@@ -129,7 +129,7 @@ abstract class _$$SurveyItemDataImplCopyWith<$Res>
       String identifier,
       String description,
       String type,
-      String response,
+      String? response,
       List<String>? choices});
 }
 
@@ -149,7 +149,7 @@ class __$$SurveyItemDataImplCopyWithImpl<$Res>
     Object? identifier = null,
     Object? description = null,
     Object? type = null,
-    Object? response = null,
+    Object? response = freezed,
     Object? choices = freezed,
   }) {
     return _then(_$SurveyItemDataImpl(
@@ -173,10 +173,10 @@ class __$$SurveyItemDataImplCopyWithImpl<$Res>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as String,
-      response: null == response
+      response: freezed == response
           ? _value.response
           : response // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       choices: freezed == choices
           ? _value._choices
           : choices // ignore: cast_nullable_to_non_nullable
@@ -223,7 +223,7 @@ class _$SurveyItemDataImpl
   @override
   final String type;
   @override
-  final String response;
+  final String? response;
 
   /// Possible choices the participant select from.
   final List<String>? _choices;
@@ -309,7 +309,7 @@ abstract class _SurveyItemData implements SurveyItemData {
       required final String identifier,
       required final String description,
       required final String type,
-      required final String response,
+      required final String? response,
       final List<String>? choices}) = _$SurveyItemDataImpl;
 
   factory _SurveyItemData.fromJson(Map<String, dynamic> json) =
@@ -335,7 +335,7 @@ abstract class _SurveyItemData implements SurveyItemData {
   /// Common options are single choice, multiple choice, free text.
   String get type;
   @override
-  String get response;
+  String? get response;
   @override
 
   /// Possible choices the participant select from.

--- a/lib/src/surveys/data/survey_item_data.g.dart
+++ b/lib/src/surveys/data/survey_item_data.g.dart
@@ -17,7 +17,7 @@ _$SurveyItemDataImpl _$$SurveyItemDataImplFromJson(Map<String, dynamic> json) =>
       identifier: json['identifier'] as String,
       description: json['description'] as String,
       type: json['type'] as String,
-      response: json['response'] as String,
+      response: json['response'] as String?,
       choices:
           (json['choices'] as List<dynamic>?)?.map((e) => e as String).toList(),
     );

--- a/lib/src/surveys/demographics_survey_controller.dart
+++ b/lib/src/surveys/demographics_survey_controller.dart
@@ -76,6 +76,7 @@ class DemographicsSurveyController extends GetxController {
       identifier: config['identifier'],
       title: config['title'],
       answerFormat: answerFormat,
+      optional: true,
     );
     return question;
   }

--- a/lib/src/surveys/demographics_survey_controller.dart
+++ b/lib/src/surveys/demographics_survey_controller.dart
@@ -76,7 +76,6 @@ class DemographicsSurveyController extends GetxController {
       identifier: config['identifier'],
       title: config['title'],
       answerFormat: answerFormat,
-      optional: true,
     );
     return question;
   }

--- a/lib/src/surveys/services/rp_converters.dart
+++ b/lib/src/surveys/services/rp_converters.dart
@@ -2,11 +2,13 @@ import 'package:research_package/model.dart';
 
 /// Format the answer to an [RPQuestion].
 /// Currently supports Date and SingleChoice questions.
-String getAnswer({
-  required Iterable<dynamic> rpAnswer,
+String? getAnswer({
+  required Iterable<dynamic>? rpAnswer,
   required String itemType,
 }) {
-  if (itemType == 'Date') {
+  if (rpAnswer == null || rpAnswer.first == null) {
+    return null;
+  } else if (itemType == 'Date') {
     return rpAnswer.first;
   } else if (itemType == 'SingleChoice') {
     return rpAnswer.first.first.text as String;

--- a/lib/src/surveys/services/rp_converters.dart
+++ b/lib/src/surveys/services/rp_converters.dart
@@ -6,10 +6,11 @@ String? getAnswer({
   required Iterable<dynamic>? rpAnswer,
   required String itemType,
 }) {
-  if (rpAnswer == null || rpAnswer.first == null) {
+  if (rpAnswer == null) {
     return null;
   } else if (itemType == 'Date') {
-    return rpAnswer.first;
+    /// we assume response can only be null if the item was skipped
+    return rpAnswer.first ?? "Prefiero no contestar";
   } else if (itemType == 'SingleChoice') {
     return rpAnswer.first.first.text as String;
   } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,15 @@
 name: mdigit_span_tasks_ema
 description: "mDigitSpanTasksEMA: A mobile application for measuring verbal working memory in real-time."
-publish_to: 'none' 
+publish_to: "none"
 
 version: 0.1.0
 
 environment:
-  sdk: '>=2.18.0-216.0.dev <3.0.0'
+  sdk: ">=2.18.0-216.0.dev <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-
 
   cupertino_icons: ^1.0.2
   get: ^4.6.5
@@ -27,7 +26,11 @@ dependencies:
   firebase_auth: ^4.19.0
   flutter_local_notifications: ^17.0.0
   firebase_messaging: ^14.8.1
-  research_package: ^1.5.0
+  # research_package: ^1.5.0
+  research_package:
+    git:
+      url: https://github.com/mario-bermonti/research.package.git
+      ref: 8f72b1f876f41b420987eb0fed1fb06b1697c44b
   get_storage: ^2.1.1
   freezed_annotation: ^2.4.2
   json_annotation: ^4.9.0

--- a/test/src/surveys/demographics_survey_controller_test.dart
+++ b/test/src/surveys/demographics_survey_controller_test.dart
@@ -49,14 +49,14 @@ void main() {
 
       expect(questionActual.identifier, questionExpected.identifier);
       expect(questionActual.title, questionExpected.title);
-      final List<RPChoice> choicesActual =
+      final List<Map<String, dynamic>> choicesActual =
           questionActual.answerFormat.toJson()['choices'];
       expect(
-        choicesActual.first.toJson(),
+        choicesActual.first,
         choicesExpected.first.toJson(),
       );
       expect(
-        choicesActual.last.toJson(),
+        choicesActual.last,
         choicesExpected.last.toJson(),
       );
     },

--- a/test/src/surveys/services/rp_converters_test.dart
+++ b/test/src/surveys/services/rp_converters_test.dart
@@ -31,6 +31,29 @@ void main() {
         },
       );
       test(
+        """Given a Date itemType and a null value inside a results object of a
+        [RPStepResult] returns 'Prefiero no contestar'.""",
+        () {
+          final RPStepResult dateStep = RPStepResult(
+            identifier: "today",
+            questionTitle: "What date is it?",
+            answerFormat: RPDateTimeAnswerFormat(
+                dateTimeAnswerStyle: RPDateTimeAnswerStyle.Date),
+          );
+          dateStep.setResult(null);
+
+          const String itemType = "Date";
+          const String expectedAnswer = "Prefiero no contestar";
+
+          final String? actualAnswer = getAnswer(
+            rpAnswer: dateStep.results.values,
+            itemType: itemType,
+          );
+
+          expect(actualAnswer, expectedAnswer);
+        },
+      );
+      test(
         """Given a SingleChoice itemType and the values inside a results object 
         of a [RPStepResult] that contains 'Black' in the text field of the 
         [RPChoice] that contains its answer, returns 'Black'""",

--- a/test/src/surveys/services/rp_converters_test.dart
+++ b/test/src/surveys/services/rp_converters_test.dart
@@ -22,7 +22,7 @@ void main() {
           const String itemType = "Date";
           const String expectedAnswer = "2024-04-07 00:00:00.000";
 
-          final String actualAnswer = getAnswer(
+          final String? actualAnswer = getAnswer(
             rpAnswer: dateStep.results.values,
             itemType: itemType,
           );
@@ -64,7 +64,7 @@ void main() {
           const String itemType = "SingleChoice";
           const String expectedAnswer = "Black";
 
-          final String actualAnswer = getAnswer(
+          final String? actualAnswer = getAnswer(
             rpAnswer: colorStep.results.values,
             itemType: itemType,
           );


### PR DESCRIPTION
## Description

Survey items are not required, with an explicit option to not respond. All answers to the demographics survey are now saved and standardized values are used if study participants decide to not answer an item.

This makes it easy to understand if an item was skipped by the participant (standarized value) vs if a technical issue caused the error to not be saved.

## Related Issue

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
