### PR TITLE
Enable notifications after consent

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:mdigit_span_tasks_ema/src/auth/auth.dart';
 import 'package:mdigit_span_tasks_ema/src/auth/participant.dart';
 import 'package:mdigit_span_tasks_ema/src/digit_span_tasks/config/config.dart';
-import 'package:mdigit_span_tasks_ema/src/notifications/local_notifications.dart';
-import 'package:mdigit_span_tasks_ema/src/notifications/firebase_notifications.dart';
 import 'firebase_options.dart';
 
 Future<void> main() async {
@@ -17,8 +15,6 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   await GetStorage.init();
-  Get.put(LocalNotifications());
-  Get.put(FirebaseNotifications());
   final Participant participant =
       await Auth(auth: FirebaseAuth.instance).signIn();
   Get.put(participant, permanent: true);

--- a/lib/src/home/initial_route_middleware.dart
+++ b/lib/src/home/initial_route_middleware.dart
@@ -15,6 +15,7 @@ class InitialRouteMiddleware extends GetMiddleware {
     } else if (!demographicsSurveyCompleted) {
       return const RouteSettings(name: '/demographicsSurvey');
     }
+
     return const RouteSettings(name: '/tasklist');
   }
 }

--- a/lib/src/informed_consent/consent_controller.dart
+++ b/lib/src/informed_consent/consent_controller.dart
@@ -1,7 +1,9 @@
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/firebase_notifications.dart';
 import 'package:research_package/research_package.dart';
 
+import '../notifications/local_notifications.dart';
 import 'consent_steps.dart';
 
 class ConsentController extends GetxController {
@@ -16,9 +18,15 @@ class ConsentController extends GetxController {
     closeAfterFinished: false,
   );
 
-  /// Marks consent as completed so it is not presented again.
+  /// Marks consent as completed and initializes notifications.
+  /// This ensures that consent is not presented again and that notifications
+  /// are only enabled after participants has consented to being part of the
+  /// study.
   Future<void> completeConsent() async {
     await GetStorage().write('consentCompleted', true);
+
+    Get.put(LocalNotifications());
+    Get.put(FirebaseNotifications());
   }
 
   void nextScreen() {


### PR DESCRIPTION
## Description

Only enable notifications after the user has consented to participate in the study. This required initializing notifications in the function called by the consent form page after the user has consented to participate in the study.

## Related Issue

Closes #91

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
