### PR TITLE
Allow starting a new digit span task while a digit span task is already running

### DIFF
--- a/lib/src/ema/run_ema_tasks.dart
+++ b/lib/src/ema/run_ema_tasks.dart
@@ -36,6 +36,10 @@ Future<void> runEMATasks() async {
   config.nextScreen = '/loading';
   emaTasks.shuffle();
   for (Function emaTask in emaTasks) {
+    // TODO: Find a better solution. See issue #99.
+    /// This temporary solution allows starting a cognitive task if a cognitive
+    /// task is already running, but has serious side effects.
+    Get.deleteAll();
     await emaTask();
   }
   Get.toNamed('/');


### PR DESCRIPTION
## Description

These changes allow starting a new digit span task even if a digit span task is already running. It introduces some undesirable side effects that we will address in the future (see issue #99).

## Related Issue

Closes #93

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
