### PR TITLE
Save notification metadata to db

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,8 +10,8 @@ import 'package:mdigit_span_tasks_ema/src/core/ema_db/participant/models/partici
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/study_progress_step.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/status.dart';
 import 'package:mdigit_span_tasks_ema/src/digit_span_tasks/config/config.dart';
-import 'package:mdigit_span_tasks_ema/src/notifications/notifications_manager.dart';
 import 'package:mdigit_span_tasks_ema/src/core/participant/participant_service.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications_service.dart';
 import 'package:mdigit_span_tasks_ema/src/study_progress/study_progress_service.dart';
 import 'firebase_options.dart';
 
@@ -35,15 +35,15 @@ Future<void> main() async {
   studyProgressService.saveFirstAppLaunch(participantId: participant.id);
   Get.put(participant, permanent: true);
   Get.put(DigitSpanTaskConfig(), permanent: true);
-  final NotificationsManager notificationManager =
-      Get.put(NotificationsManager(participantId: participant.id));
+  final NotificationService notificationService =
+      NotificationService.init(participantId: participant.id);
   final StudyProgressStep? consentStep = await studyProgressService.get(
     participantId: participant.id,
     stepId: 'consentStep',
   );
   if (consentStep?.status == Status.completed) {
-    await notificationManager.initNotifications();
-    final String? token = await notificationManager.getToken();
+    await notificationService.initNotifications();
+    final String? token = await notificationService.getToken();
     if (token != null) {
       final ema_participant.Participant emaParticipant =
           ema_participant.Participant(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ Future<void> main() async {
   Get.put(participant, permanent: true);
   Get.put(DigitSpanTaskConfig(), permanent: true);
   final NotificationsManager notificationManager =
-      Get.put(NotificationsManager());
+      Get.put(NotificationsManager(participantId: participant.id));
   final StudyProgressStep? consentStep = await studyProgressService.get(
     participantId: participant.id,
     stepId: 'consentStep',

--- a/lib/src/core/ema_db/notifications/models/notification.dart
+++ b/lib/src/core/ema_db/notifications/models/notification.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/models/ema_model.dart';
+
+part 'notification.freezed.dart';
+part 'notification.g.dart';
+
+@freezed
+class Notification extends EMAModel with _$Notification {
+  const factory Notification({
+    required String participantId,
+    required String notificationId,
+    required String? notificationType,
+    required String? title,
+    required String? body,
+    required DateTime? timeSent,
+    required DateTime? timeTapped,
+  }) = _Notification;
+
+  factory Notification.fromJson(Map<String, dynamic> json) =>
+      _$NotificationFromJson(json);
+}

--- a/lib/src/core/ema_db/notifications/models/notification.freezed.dart
+++ b/lib/src/core/ema_db/notifications/models/notification.freezed.dart
@@ -1,0 +1,281 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Notification _$NotificationFromJson(Map<String, dynamic> json) {
+  return _Notification.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Notification {
+  String get participantId => throw _privateConstructorUsedError;
+  String get notificationId => throw _privateConstructorUsedError;
+  String? get notificationType => throw _privateConstructorUsedError;
+  String? get title => throw _privateConstructorUsedError;
+  String? get body => throw _privateConstructorUsedError;
+  DateTime? get timeSent => throw _privateConstructorUsedError;
+  DateTime? get timeTapped => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $NotificationCopyWith<Notification> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationCopyWith<$Res> {
+  factory $NotificationCopyWith(
+          Notification value, $Res Function(Notification) then) =
+      _$NotificationCopyWithImpl<$Res, Notification>;
+  @useResult
+  $Res call(
+      {String participantId,
+      String notificationId,
+      String? notificationType,
+      String? title,
+      String? body,
+      DateTime? timeSent,
+      DateTime? timeTapped});
+}
+
+/// @nodoc
+class _$NotificationCopyWithImpl<$Res, $Val extends Notification>
+    implements $NotificationCopyWith<$Res> {
+  _$NotificationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? participantId = null,
+    Object? notificationId = null,
+    Object? notificationType = freezed,
+    Object? title = freezed,
+    Object? body = freezed,
+    Object? timeSent = freezed,
+    Object? timeTapped = freezed,
+  }) {
+    return _then(_value.copyWith(
+      participantId: null == participantId
+          ? _value.participantId
+          : participantId // ignore: cast_nullable_to_non_nullable
+              as String,
+      notificationId: null == notificationId
+          ? _value.notificationId
+          : notificationId // ignore: cast_nullable_to_non_nullable
+              as String,
+      notificationType: freezed == notificationType
+          ? _value.notificationType
+          : notificationType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timeSent: freezed == timeSent
+          ? _value.timeSent
+          : timeSent // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      timeTapped: freezed == timeTapped
+          ? _value.timeTapped
+          : timeTapped // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationImplCopyWith<$Res>
+    implements $NotificationCopyWith<$Res> {
+  factory _$$NotificationImplCopyWith(
+          _$NotificationImpl value, $Res Function(_$NotificationImpl) then) =
+      __$$NotificationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String participantId,
+      String notificationId,
+      String? notificationType,
+      String? title,
+      String? body,
+      DateTime? timeSent,
+      DateTime? timeTapped});
+}
+
+/// @nodoc
+class __$$NotificationImplCopyWithImpl<$Res>
+    extends _$NotificationCopyWithImpl<$Res, _$NotificationImpl>
+    implements _$$NotificationImplCopyWith<$Res> {
+  __$$NotificationImplCopyWithImpl(
+      _$NotificationImpl _value, $Res Function(_$NotificationImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? participantId = null,
+    Object? notificationId = null,
+    Object? notificationType = freezed,
+    Object? title = freezed,
+    Object? body = freezed,
+    Object? timeSent = freezed,
+    Object? timeTapped = freezed,
+  }) {
+    return _then(_$NotificationImpl(
+      participantId: null == participantId
+          ? _value.participantId
+          : participantId // ignore: cast_nullable_to_non_nullable
+              as String,
+      notificationId: null == notificationId
+          ? _value.notificationId
+          : notificationId // ignore: cast_nullable_to_non_nullable
+              as String,
+      notificationType: freezed == notificationType
+          ? _value.notificationType
+          : notificationType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timeSent: freezed == timeSent
+          ? _value.timeSent
+          : timeSent // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      timeTapped: freezed == timeTapped
+          ? _value.timeTapped
+          : timeTapped // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NotificationImpl implements _Notification {
+  const _$NotificationImpl(
+      {required this.participantId,
+      required this.notificationId,
+      required this.notificationType,
+      required this.title,
+      required this.body,
+      required this.timeSent,
+      required this.timeTapped});
+
+  factory _$NotificationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NotificationImplFromJson(json);
+
+  @override
+  final String participantId;
+  @override
+  final String notificationId;
+  @override
+  final String? notificationType;
+  @override
+  final String? title;
+  @override
+  final String? body;
+  @override
+  final DateTime? timeSent;
+  @override
+  final DateTime? timeTapped;
+
+  @override
+  String toString() {
+    return 'Notification(participantId: $participantId, notificationId: $notificationId, notificationType: $notificationType, title: $title, body: $body, timeSent: $timeSent, timeTapped: $timeTapped)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationImpl &&
+            (identical(other.participantId, participantId) ||
+                other.participantId == participantId) &&
+            (identical(other.notificationId, notificationId) ||
+                other.notificationId == notificationId) &&
+            (identical(other.notificationType, notificationType) ||
+                other.notificationType == notificationType) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.timeSent, timeSent) ||
+                other.timeSent == timeSent) &&
+            (identical(other.timeTapped, timeTapped) ||
+                other.timeTapped == timeTapped));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, participantId, notificationId,
+      notificationType, title, body, timeSent, timeTapped);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
+      __$$NotificationImplCopyWithImpl<_$NotificationImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NotificationImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Notification implements Notification {
+  const factory _Notification(
+      {required final String participantId,
+      required final String notificationId,
+      required final String? notificationType,
+      required final String? title,
+      required final String? body,
+      required final DateTime? timeSent,
+      required final DateTime? timeTapped}) = _$NotificationImpl;
+
+  factory _Notification.fromJson(Map<String, dynamic> json) =
+      _$NotificationImpl.fromJson;
+
+  @override
+  String get participantId;
+  @override
+  String get notificationId;
+  @override
+  String? get notificationType;
+  @override
+  String? get title;
+  @override
+  String? get body;
+  @override
+  DateTime? get timeSent;
+  @override
+  DateTime? get timeTapped;
+  @override
+  @JsonKey(ignore: true)
+  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/core/ema_db/notifications/models/notification.g.dart
+++ b/lib/src/core/ema_db/notifications/models/notification.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$NotificationImpl _$$NotificationImplFromJson(Map<String, dynamic> json) =>
+    _$NotificationImpl(
+      participantId: json['participantId'] as String,
+      notificationId: json['notificationId'] as String,
+      notificationType: json['notificationType'] as String?,
+      title: json['title'] as String?,
+      body: json['body'] as String?,
+      timeSent: json['timeSent'] == null
+          ? null
+          : DateTime.parse(json['timeSent'] as String),
+      timeTapped: json['timeTapped'] == null
+          ? null
+          : DateTime.parse(json['timeTapped'] as String),
+    );
+
+Map<String, dynamic> _$$NotificationImplToJson(_$NotificationImpl instance) =>
+    <String, dynamic>{
+      'participantId': instance.participantId,
+      'notificationId': instance.notificationId,
+      'notificationType': instance.notificationType,
+      'title': instance.title,
+      'body': instance.body,
+      'timeSent': instance.timeSent?.toIso8601String(),
+      'timeTapped': instance.timeTapped?.toIso8601String(),
+    };

--- a/lib/src/core/ema_db/notifications/notification_repository.dart
+++ b/lib/src/core/ema_db/notifications/notification_repository.dart
@@ -1,0 +1,25 @@
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/datasources/remote_datasource.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/models/notification.dart';
+
+/// Provides a simple interface for managing [Notification] metadata.
+class NotificationRepository {
+  final RemoteDataSource _remoteDataSource;
+
+  NotificationRepository({
+    required RemoteDataSource remoteDataSource,
+  }) : _remoteDataSource = remoteDataSource;
+
+  /// Saves [notification] to the remote database.
+  ///
+  /// [pathRemoteDB] must be a valid path that can be used to create a collection
+  /// reference in the Firestore database.
+  Future<void> save({
+    required Notification notification,
+    required String pathRemoteDB,
+  }) async {
+    await _remoteDataSource.saveEMAModel(
+      emaModel: notification,
+      path: pathRemoteDB,
+    );
+  }
+}

--- a/lib/src/informed_consent/consent_controller.dart
+++ b/lib/src/informed_consent/consent_controller.dart
@@ -50,7 +50,7 @@ class ConsentController extends GetxController {
 
     /// Setup/init notifications
     final NotificationsManager notificationsManager =
-        Get.put(NotificationsManager());
+        Get.put(NotificationsManager(participantId: participant.id));
     await notificationsManager.setupNotifications();
     await notificationsManager.initNotifications();
 

--- a/lib/src/informed_consent/consent_controller.dart
+++ b/lib/src/informed_consent/consent_controller.dart
@@ -6,8 +6,8 @@ import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/study_prog
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/status.dart';
 import 'package:mdigit_span_tasks_ema/src/core/participant/app_service.dart';
 import 'package:mdigit_span_tasks_ema/src/core/participant/location_services.dart';
-import 'package:mdigit_span_tasks_ema/src/notifications/notifications_manager.dart';
 import 'package:mdigit_span_tasks_ema/src/core/participant/participant_service.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications_service.dart';
 import 'package:mdigit_span_tasks_ema/src/study_progress/study_progress_service.dart';
 import 'package:research_package/research_package.dart';
 
@@ -49,12 +49,12 @@ class ConsentController extends GetxController {
     );
 
     /// Setup/init notifications
-    final NotificationsManager notificationsManager =
-        Get.put(NotificationsManager(participantId: participant.id));
-    await notificationsManager.setupNotifications();
-    await notificationsManager.initNotifications();
+    final NotificationService notificationService =
+        NotificationService.init(participantId: participant.id);
+    await notificationService.setupNotifications();
+    await notificationService.initNotifications();
 
-    if (notificationsManager.localNotificationsEnabled) {
+    if (notificationService.localNotificationsEnabled) {
       final StudyProgressStep localNotificationStep = StudyProgressStep(
         participantId: participant.id,
         stepId: "localNotificationStep",
@@ -67,7 +67,7 @@ class ConsentController extends GetxController {
       await studyProgressService.save(progressStep: localNotificationStep);
     }
 
-    if (notificationsManager.remoteNotificationsEnabled) {
+    if (notificationService.remoteNotificationsEnabled) {
       final StudyProgressStep remoteNotificationStep = StudyProgressStep(
         participantId: participant.id,
         stepId: "remoteNotificationStep",
@@ -91,7 +91,7 @@ class ConsentController extends GetxController {
     );
 
     /// Collect remote notification tokens.
-    final String? token = await notificationsManager.getToken();
+    final String? token = await notificationService.getToken();
     if (token != null) {
       emaParticipant = emaParticipant.copyWith(
         notificationTokens: [token],

--- a/lib/src/landing/landing_controller.dart
+++ b/lib/src/landing/landing_controller.dart
@@ -2,7 +2,7 @@ import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/study_progress_step.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/status.dart';
-import 'package:mdigit_span_tasks_ema/src/notifications/notifications_manager.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications_service.dart';
 import 'package:mdigit_span_tasks_ema/src/study_progress/study_progress_service.dart';
 
 import '../auth/participant.dart';
@@ -11,12 +11,14 @@ class LandingController extends GetxController {
   String nextScreen = '';
   GetStorage storage = GetStorage();
   final StudyProgressService studyProgressService = StudyProgressService.init();
-  final NotificationsManager _notificationsManager = Get.find();
   final Participant participant = Get.find();
   RxBool isLoading = false.obs;
 
   Future<void> determineNextScreen() async {
     isLoading.value = true;
+    final NotificationService notificationService =
+        NotificationService.init(participantId: participant.id);
+
     final StudyProgressStep? consentStep = await studyProgressService.get(
       participantId: participant.id,
       stepId: 'consentStep',
@@ -32,7 +34,7 @@ class LandingController extends GetxController {
 
     if (!consentCompleted) {
       nextScreen = 'consent';
-    } else if (_notificationsManager.notificationWhileOnTerminated != null) {
+    } else if (notificationService.notificationWhileOnTerminated != null) {
       nextScreen = 'emaScreen';
     } else if (!demographicsSurveyCompleted) {
       nextScreen = 'demographicsSurvey';

--- a/lib/src/notifications/models/notification.dart
+++ b/lib/src/notifications/models/notification.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification.freezed.dart';
+part 'notification.g.dart';
+
+@freezed
+class Notification with _$Notification {
+  factory Notification({
+    required String notificationId,
+    required String? notificationType,
+    required String? title,
+    required String? body,
+    required DateTime? timeSent,
+    required DateTime? timeTapped,
+  }) = _Notification;
+
+  factory Notification.fromJson(Map<String, dynamic> json) =>
+      _$NotificationFromJson(json);
+}

--- a/lib/src/notifications/models/notification.freezed.dart
+++ b/lib/src/notifications/models/notification.freezed.dart
@@ -1,0 +1,260 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Notification _$NotificationFromJson(Map<String, dynamic> json) {
+  return _Notification.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Notification {
+  String get notificationId => throw _privateConstructorUsedError;
+  String? get notificationType => throw _privateConstructorUsedError;
+  String? get title => throw _privateConstructorUsedError;
+  String? get body => throw _privateConstructorUsedError;
+  DateTime? get timeSent => throw _privateConstructorUsedError;
+  DateTime? get timeTapped => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $NotificationCopyWith<Notification> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationCopyWith<$Res> {
+  factory $NotificationCopyWith(
+          Notification value, $Res Function(Notification) then) =
+      _$NotificationCopyWithImpl<$Res, Notification>;
+  @useResult
+  $Res call(
+      {String notificationId,
+      String? notificationType,
+      String? title,
+      String? body,
+      DateTime? timeSent,
+      DateTime? timeTapped});
+}
+
+/// @nodoc
+class _$NotificationCopyWithImpl<$Res, $Val extends Notification>
+    implements $NotificationCopyWith<$Res> {
+  _$NotificationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? notificationId = null,
+    Object? notificationType = freezed,
+    Object? title = freezed,
+    Object? body = freezed,
+    Object? timeSent = freezed,
+    Object? timeTapped = freezed,
+  }) {
+    return _then(_value.copyWith(
+      notificationId: null == notificationId
+          ? _value.notificationId
+          : notificationId // ignore: cast_nullable_to_non_nullable
+              as String,
+      notificationType: freezed == notificationType
+          ? _value.notificationType
+          : notificationType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timeSent: freezed == timeSent
+          ? _value.timeSent
+          : timeSent // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      timeTapped: freezed == timeTapped
+          ? _value.timeTapped
+          : timeTapped // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationImplCopyWith<$Res>
+    implements $NotificationCopyWith<$Res> {
+  factory _$$NotificationImplCopyWith(
+          _$NotificationImpl value, $Res Function(_$NotificationImpl) then) =
+      __$$NotificationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String notificationId,
+      String? notificationType,
+      String? title,
+      String? body,
+      DateTime? timeSent,
+      DateTime? timeTapped});
+}
+
+/// @nodoc
+class __$$NotificationImplCopyWithImpl<$Res>
+    extends _$NotificationCopyWithImpl<$Res, _$NotificationImpl>
+    implements _$$NotificationImplCopyWith<$Res> {
+  __$$NotificationImplCopyWithImpl(
+      _$NotificationImpl _value, $Res Function(_$NotificationImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? notificationId = null,
+    Object? notificationType = freezed,
+    Object? title = freezed,
+    Object? body = freezed,
+    Object? timeSent = freezed,
+    Object? timeTapped = freezed,
+  }) {
+    return _then(_$NotificationImpl(
+      notificationId: null == notificationId
+          ? _value.notificationId
+          : notificationId // ignore: cast_nullable_to_non_nullable
+              as String,
+      notificationType: freezed == notificationType
+          ? _value.notificationType
+          : notificationType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timeSent: freezed == timeSent
+          ? _value.timeSent
+          : timeSent // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      timeTapped: freezed == timeTapped
+          ? _value.timeTapped
+          : timeTapped // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NotificationImpl implements _Notification {
+  _$NotificationImpl(
+      {required this.notificationId,
+      required this.notificationType,
+      required this.title,
+      required this.body,
+      required this.timeSent,
+      required this.timeTapped});
+
+  factory _$NotificationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NotificationImplFromJson(json);
+
+  @override
+  final String notificationId;
+  @override
+  final String? notificationType;
+  @override
+  final String? title;
+  @override
+  final String? body;
+  @override
+  final DateTime? timeSent;
+  @override
+  final DateTime? timeTapped;
+
+  @override
+  String toString() {
+    return 'Notification(notificationId: $notificationId, notificationType: $notificationType, title: $title, body: $body, timeSent: $timeSent, timeTapped: $timeTapped)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationImpl &&
+            (identical(other.notificationId, notificationId) ||
+                other.notificationId == notificationId) &&
+            (identical(other.notificationType, notificationType) ||
+                other.notificationType == notificationType) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.timeSent, timeSent) ||
+                other.timeSent == timeSent) &&
+            (identical(other.timeTapped, timeTapped) ||
+                other.timeTapped == timeTapped));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, notificationId, notificationType,
+      title, body, timeSent, timeTapped);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
+      __$$NotificationImplCopyWithImpl<_$NotificationImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NotificationImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Notification implements Notification {
+  factory _Notification(
+      {required final String notificationId,
+      required final String? notificationType,
+      required final String? title,
+      required final String? body,
+      required final DateTime? timeSent,
+      required final DateTime? timeTapped}) = _$NotificationImpl;
+
+  factory _Notification.fromJson(Map<String, dynamic> json) =
+      _$NotificationImpl.fromJson;
+
+  @override
+  String get notificationId;
+  @override
+  String? get notificationType;
+  @override
+  String? get title;
+  @override
+  String? get body;
+  @override
+  DateTime? get timeSent;
+  @override
+  DateTime? get timeTapped;
+  @override
+  @JsonKey(ignore: true)
+  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/notifications/models/notification.g.dart
+++ b/lib/src/notifications/models/notification.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$NotificationImpl _$$NotificationImplFromJson(Map<String, dynamic> json) =>
+    _$NotificationImpl(
+      notificationId: json['notificationId'] as String,
+      notificationType: json['notificationType'] as String?,
+      title: json['title'] as String?,
+      body: json['body'] as String?,
+      timeSent: json['timeSent'] == null
+          ? null
+          : DateTime.parse(json['timeSent'] as String),
+      timeTapped: json['timeTapped'] == null
+          ? null
+          : DateTime.parse(json['timeTapped'] as String),
+    );
+
+Map<String, dynamic> _$$NotificationImplToJson(_$NotificationImpl instance) =>
+    <String, dynamic>{
+      'notificationId': instance.notificationId,
+      'notificationType': instance.notificationType,
+      'title': instance.title,
+      'body': instance.body,
+      'timeSent': instance.timeSent?.toIso8601String(),
+      'timeTapped': instance.timeTapped?.toIso8601String(),
+    };

--- a/lib/src/notifications/notifications_service.dart
+++ b/lib/src/notifications/notifications_service.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:get/get.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/datasources/firebase_datasource.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/notification_repository.dart';
@@ -11,6 +12,16 @@ class NotificationService extends GetxController {
   final String _participantId;
   final NotificationsManager _notificationManager;
   final NotificationRepository _notificationRepository;
+
+  /// Returns the token used to send remote notifications to user.
+  Future<String?> getToken() async => await _notificationManager.getToken();
+
+  bool get localNotificationsEnabled =>
+      _notificationManager.localNotificationsEnabled;
+  bool get remoteNotificationsEnabled =>
+      _notificationManager.remoteNotificationsEnabled;
+  RemoteMessage? get notificationWhileOnTerminated =>
+      _notificationManager.notificationWhileOnTerminated;
 
   NotificationService({
     required String participantId,
@@ -27,6 +38,14 @@ class NotificationService extends GetxController {
             remoteDataSource:
                 FirebaseDataSource(db: FirebaseFirestore.instance)) {
     _notificationManager.handleData = save;
+  }
+
+  Future<void> setupNotifications() async {
+    await _notificationManager.setupNotifications();
+  }
+
+  Future<void> initNotifications() async {
+    await _notificationManager.initNotifications();
   }
 
   /// Save notification to the remote db.

--- a/lib/src/notifications/notifications_service.dart
+++ b/lib/src/notifications/notifications_service.dart
@@ -1,0 +1,50 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/datasources/firebase_datasource.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/notification_repository.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/models/notification.dart'
+    as notification_model;
+import 'package:mdigit_span_tasks_ema/src/notifications/models/notification.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications_manager.dart';
+
+class NotificationService extends GetxController {
+  final String _participantId;
+  final NotificationsManager _notificationManager;
+  final NotificationRepository _notificationRepository;
+
+  NotificationService({
+    required String participantId,
+    required NotificationsManager notificationManager,
+    required NotificationRepository notificationRepository,
+  })  : _participantId = participantId,
+        _notificationManager = notificationManager,
+        _notificationRepository = notificationRepository;
+
+  NotificationService.init({required String participantId})
+      : _participantId = participantId,
+        _notificationManager = NotificationsManager(),
+        _notificationRepository = NotificationRepository(
+            remoteDataSource:
+                FirebaseDataSource(db: FirebaseFirestore.instance)) {
+    _notificationManager.handleData = save;
+  }
+
+  /// Save notification to the remote db.
+  Future<void> save({required Notification notification}) async {
+    final notification_model.Notification notificationModel =
+        notification_model.Notification(
+      participantId: _participantId,
+      notificationId: notification.notificationId,
+      notificationType: notification.notificationType,
+      title: notification.title,
+      body: notification.body,
+      timeSent: notification.timeSent,
+      timeTapped: notification.timeTapped,
+    );
+
+    final String pathRemoteDB =
+        'notifications/$_participantId/${notification.notificationId}';
+    await _notificationRepository.save(
+        notification: notificationModel, pathRemoteDB: pathRemoteDB);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
     sdk: flutter
   intl: ^0.18.1
   package_info_plus: ^8.0.2
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:

--- a/test/src/core/ema_db/notifications/notification_repository_test.dart
+++ b/test/src/core/ema_db/notifications/notification_repository_test.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/datasources/firebase_datasource.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/models/notification.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/notification_repository.dart';
+
+import '../../../ema_db/test_data/notification.dart';
+
+void main() {
+  late FirebaseDataSource firebaseDataSource;
+  late NotificationRepository repository;
+
+  setUp(
+    () {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      firebaseDataSource = FirebaseDataSource(db: FakeFirebaseFirestore());
+      repository = NotificationRepository(
+        remoteDataSource: firebaseDataSource,
+      );
+    },
+  );
+  tearDown(() async {
+    await firebaseDataSource.db.clearPersistence();
+  });
+  group('ParticipantRepository.save', () {
+    test(
+        "Given a [Notification], [pathRemoteDB], saves the data to "
+        "the remote db.", () async {
+      await repository.save(
+        notification: testNotification,
+        pathRemoteDB: testPathRemoteDB,
+      );
+
+      final QuerySnapshot<Map<String, dynamic>> snapshot =
+          await firebaseDataSource.db.collection(testPathRemoteDB).get();
+      final Notification actualNotification =
+          Notification.fromJson(snapshot.docs.first.data());
+
+      expect(actualNotification, testNotification);
+    });
+  });
+}

--- a/test/src/ema_db/test_data/notification.dart
+++ b/test/src/ema_db/test_data/notification.dart
@@ -1,0 +1,14 @@
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/models/notification.dart';
+
+final Notification testNotification = Notification(
+  participantId: 'testParticipantId',
+  notificationId: 'testNotificationId',
+  notificationType: 'testNotificationType',
+  title: 'testTitle',
+  body: 'testBody',
+  timeSent: DateTime.now(),
+  timeTapped: DateTime.now(),
+);
+
+final String testPathRemoteDB =
+    'notifications/participants/${testNotification.participantId}';

--- a/test/src/notifications/notifications_service_test.dart
+++ b/test/src/notifications/notifications_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/datasources/firebase_datasource.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/models/notification.dart'
+    as ema_db;
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/notification_repository.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications_manager.dart';
+import 'package:mdigit_span_tasks_ema/src/notifications/notifications_service.dart';
+
+import 'test_data.dart';
+
+class NotificationsManagerMock extends Fake implements NotificationsManager {}
+
+void main() {
+  late NotificationsManagerMock notificationsManager;
+  late FakeFirebaseFirestore fakeFirebaseFirestore;
+  late NotificationService notificationService;
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    notificationsManager = NotificationsManagerMock();
+    fakeFirebaseFirestore = FakeFirebaseFirestore();
+    NotificationRepository repo = NotificationRepository(
+        remoteDataSource: FirebaseDataSource(db: fakeFirebaseFirestore));
+    notificationService = NotificationService(
+        notificationManager: notificationsManager,
+        participantId: participantId,
+        notificationRepository: repo);
+  });
+
+  tearDown(() async {
+    await fakeFirebaseFirestore.clearPersistence();
+  });
+
+  group("NotificationService.save", () {
+    test(
+      "Given a notification handler's [Notification], "
+      "saves a [ema_db]'s [Notification] to the remote db.",
+      () async {
+        await notificationService.save(notification: testHandlerNotification);
+
+        final QuerySnapshot<
+            Map<String,
+                dynamic>> notificationsSnapshot = await fakeFirebaseFirestore
+            .collection(
+                'notifications/$participantId/${testHandlerNotification.notificationId}')
+            .get();
+
+        final ema_db.Notification actualNotification =
+            ema_db.Notification.fromJson(
+                notificationsSnapshot.docs.first.data());
+
+        expect(actualNotification, testEmadbNotification);
+      },
+    );
+  });
+}

--- a/test/src/notifications/test_data.dart
+++ b/test/src/notifications/test_data.dart
@@ -1,0 +1,28 @@
+import 'package:mdigit_span_tasks_ema/src/notifications/models/notification.dart';
+import 'package:mdigit_span_tasks_ema/src/core/ema_db/notifications/models/notification.dart'
+    as ema_db;
+
+const String participantId = '101';
+final DateTime now = DateTime.now();
+
+Notification testHandlerNotification = Notification(
+  notificationId: 'testNotificationId',
+  notificationType: 'testNotificationType',
+  title: 'testTitle',
+  body: 'testBody',
+  timeSent: now,
+  timeTapped: now,
+);
+
+ema_db.Notification testEmadbNotification = ema_db.Notification(
+  participantId: participantId,
+  notificationId: 'testNotificationId',
+  notificationType: 'testNotificationType',
+  title: 'testTitle',
+  body: 'testBody',
+  timeSent: now,
+  timeTapped: now,
+);
+
+final String pathRemoteDB =
+    'notifications/$participantId/${testHandlerNotification.notificationId}';


### PR DESCRIPTION
## Description

Save the notification metadata to the remote db. A data repo was implemented to handle data logic.

A notification service was implemented that abstracts away the notification manager (handler) and manages interaction between the manager (getting data) and the repo (saving the data). This service became the only object that the application now interacts with.

Only the data from the notifications that have been tapped on are stored.

## Related Issue

Closes #115

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
