### PR TITLE
Handle cancelling the informed consent or demographics survey

### DIFF
--- a/lib/src/core/navigator_service/navigator_service.dart
+++ b/lib/src/core/navigator_service/navigator_service.dart
@@ -8,6 +8,7 @@ import '../../auth/participant.dart';
 
 class NavigatorService extends GetxService {
   bool notificationsPermissionAsked = false;
+  bool demographicsSurveyAsked = false;
   final StudyProgressService studyProgressService = StudyProgressService.init();
   final Participant participant = Get.find();
 
@@ -38,7 +39,9 @@ class NavigatorService extends GetxService {
     } else if (notificationsManagerService.notificationWhileOnTerminated !=
         null) {
       return 'emaScreen';
-    } else if (!demographicsSurveyCompleted) {
+    } else if (!demographicsSurveyCompleted &&
+        demographicsSurveyAsked == false) {
+      demographicsSurveyAsked = true;
       return 'demographicsSurvey';
     } else {
       return 'tasklist';

--- a/lib/src/demographics/close_demographics_screen.dart
+++ b/lib/src/demographics/close_demographics_screen.dart
@@ -1,0 +1,8 @@
+import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/core/navigator_service/navigator_service.dart';
+
+Future<void> closeDemographicsScreen() async {
+  final NavigatorService navigatorService = Get.find();
+  final String nextScreen = await navigatorService.determineNextScreen();
+  Get.offAndToNamed(nextScreen);
+}

--- a/lib/src/demographics/end_demographics_survey.dart
+++ b/lib/src/demographics/end_demographics_survey.dart
@@ -2,7 +2,7 @@ import 'package:get/get.dart';
 import 'package:mdigit_span_tasks_ema/src/auth/participant.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/study_progress_step.dart';
 import 'package:mdigit_span_tasks_ema/src/core/ema_db/progress/models/status.dart';
-import 'package:mdigit_span_tasks_ema/src/core/navigator_service/navigator_service.dart';
+import 'package:mdigit_span_tasks_ema/src/demographics/close_demographics_screen.dart';
 import 'package:mdigit_span_tasks_ema/src/demographics/process_demographics_data.dart';
 import 'package:mdigit_span_tasks_ema/src/study_progress/study_progress_service.dart';
 import 'package:research_package/research_package.dart';
@@ -25,7 +25,5 @@ Future<void> endDemographicsSurvey(RPTaskResult results) async {
   final StudyProgressService studyProgressService = StudyProgressService.init();
   await studyProgressService.save(progressStep: progressStep);
 
-  final NavigatorService navigatorService = Get.find();
-  final String nextScreen = await navigatorService.determineNextScreen();
-  Get.offAndToNamed(nextScreen);
+  await closeDemographicsScreen();
 }

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:mdigit_span_tasks_ema/src/demographics/close_demographics_screen.dart';
 import 'package:mdigit_span_tasks_ema/src/demographics/end_demographics_survey.dart';
 import 'package:mdigit_span_tasks_ema/src/ema/ema_screen.dart';
 import 'package:mdigit_span_tasks_ema/src/informed_consent/consent_screen.dart';
@@ -15,6 +16,7 @@ final List<GetPage> routes = <GetPage>[
       name: '/demographicsSurvey',
       page: () => DemographicsSurvey(
             onSubmit: endDemographicsSurvey,
+            onCancel: closeDemographicsScreen,
           )),
   GetPage(name: '/emaScreen', page: () => const EMAScreen()),
   GetPage(name: '/loading', page: () => const LoadingScreen()),

--- a/lib/src/surveys/demographics_survey.dart
+++ b/lib/src/surveys/demographics_survey.dart
@@ -10,8 +10,13 @@ class DemographicsSurvey extends StatelessWidget {
   final DemographicsSurveyController controller =
       Get.put(DemographicsSurveyController());
   final Function onSubmit;
+  final Function onCancel;
 
-  DemographicsSurvey({super.key, required this.onSubmit});
+  DemographicsSurvey({
+    super.key,
+    required this.onSubmit,
+    required this.onCancel,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -28,6 +33,7 @@ class DemographicsSurvey extends StatelessWidget {
         return RPUITask(
           task: survey,
           onSubmit: (RPTaskResult results) async => await onSubmit(results),
+          onCancel: (RPTaskResult? results) async => await onCancel(),
         );
       }
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   research_package:
     git:
       url: https://github.com/mario-bermonti/research.package.git
-      ref: 49bec487ed151ccc24e6b3370a57f1fedfb97a12
+      ref: 90829448e20fa72ce34ee740dac25849078cb2de
   get_storage: ^2.1.1
   freezed_annotation: ^2.4.2
   json_annotation: ^4.9.0


### PR DESCRIPTION
## Description

The `research_package` was upgraded because it had a bug handling  when the user cancelled the consent or demographics survey.

Now, when users cancel the consent or demographics survey, the app redirects them to the appropriate screen. In the case of the consent, they are redirected to the informed consent again. In the case of of the demographics survey, it is only presented once for each session, just like when asking permission for notifications again.

## Related Issue

Closes #123 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
